### PR TITLE
Make plugin more versatile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Install the php-ldap extension, if you have apt:
 The plugin php script ldap_logon.php must be placed in "<zenphoto-directory>/plugins/ldap_logon.php".
 In addition the lib-auth.php must be replaced - to do this create a folder named "alt" in the plugins directory
 
- "mkdir <zenphoto-directory>/alt/plugins/alt/"
+ "mkdir &lt;zenphoto-directory&gt;/plugins/alt/"
  
 and place the alternative lib-auth.php in the alt-folder.
 
 How it works
 ============
 Basically you have to create and configure zenphoto-groups (through the zenplugin user_groups).
-The zen-groups have to exist in the LDAP-Directory too (same group-name only).
+The zen-groups are read from both the memberOf attribute of the user and the cn attribute of group entries if the server doesn't support memberOf overlay.
 During the login, the plugin receives the groups of the user. If there is a match between LDAP-group and Zenphoto-group, the zenphoto-group rights will be merged into the LDAP-user.
 If there is no match, a default-template can be defined on the plugin-option page, than those rights will be used for the user.
 

--- a/alt/lib-auth.diff
+++ b/alt/lib-auth.diff
@@ -1,0 +1,84 @@
+--- lib-auth-1.4.4.php	2017-04-07 08:26:03.185947438 +0200
++++ lib-auth.php	2017-04-07 08:21:20.797953158 +0200
+@@ -41,7 +41,11 @@
+  * @package classes
+  */
+ // force UTF-8 Ø
+-require_once(dirname(__FILE__).'/classes.php');
++require_once(dirname(__FILE__).'/../../zp-core/classes.php');
++
++/* create the global $_zp_authority object */
++global $_zp_authority;
++$_zp_authority = new Zenphoto_Authority();
+ 
+ class Zenphoto_Authority {
+ 
+@@ -241,6 +245,9 @@
+ 	function checkAuthorization($authCode, $id) {
+ 		global $_zp_current_admin_obj;
+ 		if (DEBUG_LOGIN) { debugLogBacktrace("checkAuthorization($authCode, $id)");	}
++		if(getOption('ldapEnabled') && ldapLogon::getLogon($id)){ 
++			return $_zp_current_admin_obj->getRights(); 
++		}
+ 		$admins = $this->getAdministrators();
+ 		if (count($admins) == 0) {
+ 			if (DEBUG_LOGIN) { debugLog("checkAuthorization: no admins"); }
+@@ -628,12 +635,22 @@
+ 			switch (@$_POST['password']) {
+ 				default:
+ 					$user = self::checkLogon($post_user, $post_pass);
++					if (getOption('ldapEnabled') ) { $userext = ldapLogon::checkLogon($post_user, $post_pass); }
+ 					if ($user) {
+ 						$_zp_loggedin = $user->getRights();
++						} else if (getOption('ldapEnabled') && $userext) {
++							$user = $userext;
++							$_zp_loggedin = $user->getRights();
++							if($_zp_loggedin == 1) {
++								$_zp_loggedin = 0; //No group and no default template set 
++							}
+ 					}
+ 					$_zp_loggedin = zp_apply_filter('admin_login_attempt', $_zp_loggedin, $post_user, $post_pass);
+ 					if ($_zp_loggedin) {
+ 						self::logUser($user);
++						if($user->getID() == -1) {
++							zp_setCookie("zp_user_auth_ldap",$post_user, NULL, NULL, secureServer());
++						}
+ 						$_zp_current_admin_obj = $user;
+ 					} else {
+ 						zp_clearCookie("zp_user_auth");	// Clear the cookie, just in case
+@@ -655,7 +672,7 @@
+ 					break;
+ 				case 'captcha':
+ 					if ($_zp_captcha->checkCaptcha(trim(@$_POST['code']), sanitize(@$_POST['code_h'],3))) {
+-						require_once(dirname(__FILE__).'/load_objectClasses.php'); // be sure that the plugins are loaded for the mail handler
++                                                require_once(dirname(__FILE__).'/../../zp-core/load_objectClasses.php'); // be sure that the plugins are loaded for the mail handler
+ 						if (empty($post_user)) {
+ 							$requestor = gettext('You are receiving this e-mail because of a password reset request on your Zenphoto gallery.');
+ 						} else {
+@@ -1508,7 +1525,7 @@
+ 				}
+ 				switch ($object['type']) {
+ 					case 'album':
+-						$album = new Album(NULL, $object['data']);
++						$album = newAlbum($object['data']);
+ 						$albumid = $album->getID();
+ 						$sql = "INSERT INTO ".prefix('admin_to_object')." (adminid, objectid, type, edit) VALUES ($id, $albumid, 'albums', $edit)";
+ 						$result = query($sql);
+@@ -1564,7 +1581,7 @@
+ 			$sql = 'SELECT `folder` FROM '.prefix('albums').' WHERE `id`='.$id;
+ 			$result = query_single_row($sql);
+ 			if ($result) {
+-				$album = new Album(NULL, $result['folder']);
++				$album = newAlbum($result['folder']);
+ 				return $album;
+ 			}
+ 		}
+@@ -1617,7 +1634,7 @@
+ 		$path = ALBUM_FOLDER_SERVERPATH.$filename.$ext;
+ 		$albumname = filesystemToInternal($filename.$ext);
+ 		if (@mkdir_recursive($path,FOLDER_MOD)) {
+-			$album = new Album(NULL, $albumname);
++			$album = newAlbum($albumname);
+ 			if ($title = $this->getName()) {
+ 				$album->setTitle($title);
+ 			}

--- a/alt/lib-auth.php
+++ b/alt/lib-auth.php
@@ -27,9 +27,9 @@
  * 				'group', and 'custom_data'
  *
  * 		So long as all these indices are populated it should not matter when and where
- *		the data is stored.
+ * 		the data is stored.
  *
- *		Administrator class methods are required for these elements as well.
+ * 		Administrator class methods are required for these elements as well.
  *
  * 		The getRights() method must define at least the rights defined by the method in
  * 		this library.
@@ -41,8 +41,8 @@
  * @package classes
  */
 // force UTF-8 Ø
-require_once(dirname(__FILE__).'/../../zp-core/classes.php');
-
+require_once(dirname(__FILE__) . '/../../zp-core/classes.php');
+require_once(dirname(__FILE__) . '/../../plugins/ldapLogon.php');
 /* create the global $_zp_authority object */
 global $_zp_authority;
 $_zp_authority = new Zenphoto_Authority();
@@ -54,10 +54,10 @@ class Zenphoto_Authority {
 	var $admin_other = NULL;
 	var $admin_all = NULL;
 	var $rightsset = NULL;
-	var $master_user = NULL;
+	protected $master_user = NULL;
 	static $preferred_version = 4;
 	static $supports_version = 4;
-	static $hashList =  array('pbkdf2'=>2, 'sha1'=>1, 'md5'=>0);
+	static $hashList = array('pbkdf2' => 3, 'pbkdf2*' => 2, 'sha1' => 1, 'md5' => 0);
 
 	/**
 	 * class instantiation function
@@ -65,11 +65,36 @@ class Zenphoto_Authority {
 	 * @return lib_auth_options
 	 */
 	function __construct() {
-		$sql = 'SELECT * FROM '.prefix('administrators').' WHERE `valid`=1 ORDER BY `rights` DESC, `id` LIMIT 1';
-		$master = query_single_row($sql,false);
-		if ($master) {
-			$this->master_user = $master['user'];
+		$this->admin_all = $this->admin_groups = $this->admin_users = $this->admin_other = array();
+		$sql = 'SELECT * FROM ' . prefix('administrators') . ' ORDER BY `rights` DESC, `id`';
+		$admins = query($sql, false);
+		if ($admins) {
+			while ($user = db_fetch_assoc($admins)) {
+				$this->admin_all[$user['id']] = $user;
+				switch ($user['valid']) {
+					case 1:
+						$this->admin_users[$user['id']] = $user;
+						if (empty($this->master_user))
+							$this->master_user = $user['user'];
+						break;
+					case 0:
+						$this->admin_groups[$user['id']] = $user;
+						break;
+					default:
+						$this->admin_other[$user['id']] = $user;
+						break;
+				}
+			}
+			db_free_result($admins);
 		}
+	}
+
+	function getMasterUser() {
+		return new Zenphoto_Administrator($this->master_user, 1);
+	}
+
+	function isMasterUser($user) {
+		return $user == $this->master_user;
 	}
 
 	/**
@@ -78,15 +103,19 @@ class Zenphoto_Authority {
 	 * @return array
 	 */
 	function getOptionsSupported() {
-		return array(	gettext('Primary album edit') => array('key' => 'user_album_edit_default', 'type' => OPTION_TYPE_CHECKBOX,
+		$encodings = self::$hashList;
+		unset($encodings['pbkdf2*']); // don't use this one any more
+		if (!function_exists('hash')) {
+			unset($encodings['pbkdf2']);
+		}
+		return array(gettext('Primary album edit')				 => array('key'	 => 'user_album_edit_default', 'type' => OPTION_TYPE_CHECKBOX,
 										'desc' => gettext('Check if you want <em>edit rights</em> automatically assigned when a user <em>primary album</em> is created.')),
-									gettext('Minimum password strength') => array('key' => 'password_strength', 'type' => OPTION_TYPE_CUSTOM,
-										'desc' => sprintf(gettext('Users must provide passwords a strength of at least %s. The repeat password field will be disabled until this floor is met.'),
-										'<span id="password_strength_display">'.getOption('password_strength').'</span>')),
-									gettext('Password hash algorithm')=> array('key'=>'strong_hash', 'type'=>OPTION_TYPE_SELECTOR,
-										'selections' => self::$hashList,
-										'desc'=> sprintf(gettext('The hashing algorithm used by Zenphoto. In order of robustness the choices are %s'), '<code>'.implode('</code> > <code>',array_flip(self::$hashList)).'</code>'))
-									);
+						gettext('Minimum password strength') => array('key'	 => 'password_strength', 'type' => OPTION_TYPE_CUSTOM,
+										'desc' => sprintf(gettext('Users must provide passwords a strength of at least %s. The repeat password field will be disabled until this floor is met.'), '<span id="password_strength_display">' . getOption('password_strength') . '</span>')),
+						gettext('Password hash algorithm')	 => array('key'				 => 'strong_hash', 'type'			 => OPTION_TYPE_SELECTOR,
+										'selections' => $encodings,
+										'desc'			 => sprintf(gettext('The hashing algorithm used by Zenphoto. In order of robustness the choices are %s'), '<code>' . implode('</code> > <code>', array_flip($encodings)) . '</code>'))
+		);
 	}
 
 	/**
@@ -101,12 +130,12 @@ class Zenphoto_Authority {
 				<script type="text/javascript">
 					// <!-- <![CDATA[
 					function sliderColor(strength) {
-						var url = 'url(<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/strengths/strength'+strength+'.png)';
-						$('#slider-password_strength').css('background-image',url);
+						var url = 'url(<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/strengths/strength' + strength + '.png)';
+						$('#slider-password_strength').css('background-image', url);
 					}
 					$(function() {
 						$("#slider-password_strength").slider({
-						<?php $v = getOption('password_strength'); ?>
+				<?php $v = getOption('password_strength'); ?>
 							startValue: <?php echo $v; ?>,
 							value: <?php echo $v; ?>,
 							min: 1,
@@ -146,23 +175,27 @@ class Zenphoto_Authority {
 	 * @param string $pass
 	 * @return string
 	 */
-	static function passwordHash($user, $pass, $hash_type=NULL) {
+	static function passwordHash($user, $pass, $hash_type = NULL) {
 		if (is_null($hash_type)) {
 			$hash_type = getOption('strong_hash');
 		}
 		switch ($hash_type) {
 			case 1:
-				$hash = sha1($user.$pass.HASH_SEED);
+				$hash = sha1($user . $pass . HASH_SEED);
 				break;
 			case 2:
-				$hash = base64_encode(self::pbkdf2($pass,$user.HASH_SEED));
+				//	deprecated beause of possible "+" in the text
+				$hash = base64_encode(self::pbkdf2($pass, $user . HASH_SEED));
+				break;
+			case 3:
+				$hash = str_replace('+', '-', base64_encode(self::pbkdf2($pass, $user . HASH_SEED)));
 				break;
 			default:
-				$hash = md5($user.$pass.HASH_SEED);
+				$hash = md5($user . $pass . HASH_SEED);
 				break;
 		}
 		if (DEBUG_LOGIN) {
-			debugLog("passwordHash($user, $pass, $hash_type)[{HASH_SEED}]:$hash");
+			debugLog("passwordHash($user, $pass, $hash_type)[ " . HASH_SEED . " ]:$hash");
 		}
 		return $hash;
 	}
@@ -175,29 +208,7 @@ class Zenphoto_Authority {
 	 * @param string $what: 'all' for everything, 'users' for just users 'groups' for groups and templates
 	 * @return array
 	 */
-	function getAdministrators($what='users') {
-		if (is_null($this->admin_users)) {
-			$this->admin_all = $this->admin_groups = $this->admin_users = $this->admin_other = array();
-			$sql = 'SELECT * FROM '.prefix('administrators').' ORDER BY `rights` DESC, `id`';
-			$admins = query($sql, false);
-			if ($admins) {
-				while ($user = db_fetch_assoc($admins)) {
-					$this->admin_all[$user['id']] = $user;
-					switch ($user['valid']) {
-						case 1:
-							$this->admin_users[$user['id']] = $user;
-							break;
-						case 0:
-							$this->admin_groups[$user['id']] = $user;
-							break;
-						default:
-							$this->admin_other[$user['id']] = $user;
-							break;
-					}
-				}
-				db_free_result($admins);
-			}
-		}
+	function getAdministrators($what = 'users') {
 		switch ($what) {
 			case 'users':
 				return $this->admin_users;
@@ -217,15 +228,15 @@ class Zenphoto_Authority {
 	 */
 	static function getAnAdmin($criteria) {
 		$selector = array();
-		foreach ($criteria as $match=>$value) {
+		foreach ($criteria as $match => $value) {
 			if (is_numeric($value)) {
-				$selector[] = $match.$value;
+				$selector[] = $match . $value;
 			} else {
-				$selector[] = $match.db_quote($value);
+				$selector[] = $match . db_quote($value);
 			}
 		}
-		$sql = 'SELECT * FROM '.prefix('administrators').' WHERE '.implode(' AND ',$selector).' LIMIT 1';
-		$admin = query_single_row($sql,false);
+		$sql = 'SELECT * FROM ' . prefix('administrators') . ' WHERE ' . implode(' AND ', $selector) . ' LIMIT 1';
+		$admin = query_single_row($sql, false);
 		if ($admin) {
 			return self::newAdministrator($admin['user'], $admin['valid']);
 		} else {
@@ -244,25 +255,38 @@ class Zenphoto_Authority {
 	 */
 	function checkAuthorization($authCode, $id) {
 		global $_zp_current_admin_obj;
-		if (DEBUG_LOGIN) { debugLogBacktrace("checkAuthorization($authCode, $id)");	}
+		if (DEBUG_LOGIN) {
+			debugLogBacktrace("checkAuthorization($authCode, $id)");
+		}
 		if(getOption('ldapEnabled') && ldapLogon::getLogon($id)){ 
 			return $_zp_current_admin_obj->getRights(); 
 		}
+
+
 		$admins = $this->getAdministrators();
 		if (count($admins) == 0) {
-			if (DEBUG_LOGIN) { debugLog("checkAuthorization: no admins"); }
+			if (DEBUG_LOGIN) {
+				debugLog("checkAuthorization: no admins");
+			}
 			$_zp_current_admin_obj = new Zenphoto_Administrator('', 1);
 			$_zp_current_admin_obj->set('id', 0);
 			$_zp_current_admin_obj->reset = true;
 			return ADMIN_RIGHTS;
 		}
 		if (is_object($_zp_current_admin_obj) && $_zp_current_admin_obj->reset) {
-			if (DEBUG_LOGIN) { debugLog("checkAuthorization: reset request"); }
+			if (DEBUG_LOGIN) {
+				debugLog("checkAuthorization: reset request");
+			}
 			return $_zp_current_admin_obj->getRights();
 		}
+
+
 		$_zp_current_admin_obj = NULL;
-		if (empty($authCode)) return 0; //  so we don't "match" with an empty password
-		if (DEBUG_LOGIN) { debugLogVar("checkAuthorization: admins",$admins);	}
+		if (empty($authCode))
+			return 0; //  so we don't "match" with an empty password
+		if (DEBUG_LOGIN) {
+			debugLogVar("checkAuthorization: admins", $admins);
+		}
 		$rights = 0;
 		$criteria = array('`pass`=' => $authCode, '`valid`=' => 1);
 		if (!empty($id)) {
@@ -272,39 +296,56 @@ class Zenphoto_Authority {
 		if (is_object($user)) {
 			$_zp_current_admin_obj = $user;
 			$rights = $user->getRights();
-			if (DEBUG_LOGIN) { debugLog(sprintf('checkAuthorization: from %1$s->%2$X',$authCode,$rights));	}
+			if (DEBUG_LOGIN) {
+				debugLog(sprintf('checkAuthorization: from %1$s->%2$X', $authCode, $rights));
+			}
 			return $rights;
 		}
 		$_zp_current_admin_obj = NULL;
-		if (DEBUG_LOGIN) { debugLog("checkAuthorization: no match");	}
+		if (DEBUG_LOGIN) {
+			debugLog("checkAuthorization: no match");
+		}
 		return 0; // no rights
 	}
 
 	/**
 	 * Checks a logon user/password against admins
 	 *
-	 * Returns true if there is a match
+	 * Returns the user object if there is a match
 	 *
 	 * @param string $user
 	 * @param string $pass
-	 * @return bool
+	 * @return object
 	 */
-	protected static function checkLogon($user, $pass) {
+	function checkLogon($user, $pass) {
 		$userobj = self::getAnAdmin(array('`user`=' => $user, '`valid`=' => 1));
 		if ($userobj) {
 			$hash = self::passwordHash($user, $pass, $userobj->get('passhash'));
 			if ($hash != $userobj->getPass()) {
-				$userobj = NULL;
+				//	maybe not yet updated passhash field
+				foreach (self::$hashList as $hashv) {
+					$hash = self::passwordHash($user, $pass, $hashv);
+					if ($hash == $userobj->getPass()) {
+						break;
+					} else {
+						$hash = -1;
+					}
+				}
+				if ($hash === -1) {
+					$userobj = NULL;
+				}
 			}
+		} else {
+			$hash = -1;
 		}
 
 		if (DEBUG_LOGIN) {
 			if ($userobj) {
-				$rights = sprintf('%X',$userobj->getRights());
+				$rights = sprintf('%X', $userobj->getRights());
 			} else {
 				$rights = false;
 			}
-			debugLog(sprintf('checkLogon(%1$s, %2$s)->%3$s',$user, $hash, $rights));
+			debugLog(sprintf('checkLogon(%1$s, %2$s)->%3$s', $user, $hash, $rights));
 		}
 		return $userobj;
 	}
@@ -315,14 +356,14 @@ class Zenphoto_Authority {
 	 * @param bit $rights what kind of admins to retrieve
 	 * @return array
 	 */
-	function getAdminEmail($rights=NULL) {
+	function getAdminEmail($rights = NULL) {
 		if (is_null($rights)) {
 			$rights = ADMIN_RIGHTS;
 		}
 		$emails = array();
 		$admins = $this->getAdministrators();
 		foreach ($admins as $user) {
-			if (($user['rights'] & $rights)  && is_valid_email_zp($user['email'])) {
+			if (($user['rights'] & $rights) && is_valid_email_zp($user['email'])) {
 				$name = $user['name'];
 				if (empty($name)) {
 					$name = $user['user'];
@@ -339,19 +380,19 @@ class Zenphoto_Authority {
 	 * @param int $oldversion
 	 */
 	function migrateAuth($to) {
-		if ($to > self::$supports_version || $to < self::$preferred_version-1) {
-			trigger_error(sprintf(gettext('Cannot migrate rights to version %1$s (Zenphoto_Authority supports only %2$s and %3$s.)'),$to,self::$supports_version,self::$preferred_version), E_USER_NOTICE);
+		if ($to > self::$supports_version || $to < self::$preferred_version - 1) {
+			trigger_error(sprintf(gettext('Cannot migrate rights to version %1$s (Zenphoto_Authority supports only %2$s and %3$s.)'), $to, self::$supports_version, self::$preferred_version), E_USER_NOTICE);
 			return false;
 		}
 		$success = true;
 		$oldversion = self::getVersion();
-		setOption('libauth_version',$to);
+		setOption('libauth_version', $to);
 		$this->admin_users = array();
-		$sql = "SELECT * FROM ".prefix('administrators')."ORDER BY `rights` DESC, `id`";
+		$sql = "SELECT * FROM " . prefix('administrators') . "ORDER BY `rights` DESC, `id`";
 		$admins = query($sql, false);
 		if ($admins) { // something to migrate
 			$oldrights = array();
-			foreach (self::getRights($oldversion) as $key=>$right) {
+			foreach (self::getRights($oldversion) as $key => $right) {
 				$oldrights[$key] = $right['value'];
 			}
 			$currentrights = self::getRights($to);
@@ -359,7 +400,7 @@ class Zenphoto_Authority {
 				$update = false;
 				$rights = $user['rights'];
 				$newrights = $currentrights['NO_RIGHTS']['value'];
-				foreach ($currentrights as $key=>$right) {
+				foreach ($currentrights as $key => $right) {
 					if ($right['display']) {
 						if (array_key_exists($key, $oldrights) && $rights & $oldrights[$key]) {
 							$newrights = $newrights | $right['value'];
@@ -372,8 +413,8 @@ class Zenphoto_Authority {
 				if ($to >= 3 && $oldversion < 3) {
 					if ($rights & $oldrights['VIEW_ALL_RIGHTS']) {
 						$updaterights = $currentrights['ALL_ALBUMS_RIGHTS']['value'] | $currentrights['ALL_PAGES_RIGHTS']['value'] |
-													$currentrights['ALL_NEWS_RIGHTS']['value'] | $currentrights['VIEW_SEARCH_RIGHTS']['value']	|
-													$currentrights['VIEW_GALLERY_RIGHTS']['value'] | $currentrights['VIEW_FULLIMAGE_RIGHTS']['value'];
+										$currentrights['ALL_NEWS_RIGHTS']['value'] | $currentrights['VIEW_SEARCH_RIGHTS']['value'] |
+										$currentrights['VIEW_GALLERY_RIGHTS']['value'] | $currentrights['VIEW_FULLIMAGE_RIGHTS']['value'];
 						$newrights = $newrights | $updaterights;
 					}
 				}
@@ -382,7 +423,7 @@ class Zenphoto_Authority {
 						$newrights = $newrights | $currentrights['VIEW_ALL_RIGHTS']['value'];
 					}
 				}
-				if ($oldversion == 1) {	// need to migrate zenpage rights
+				if ($oldversion == 1) { // need to migrate zenpage rights
 					if ($rights & $oldrights['ZENPAGE_RIGHTS']) {
 						$newrights = $newrights | $currentrights['ZENPAGE_PAGES_RIGHTS'] | $currentrights['ZENPAGE_NEWS_RIGHTS'] | $currentrights['FILES_RIGHTS'];
 					}
@@ -406,7 +447,7 @@ class Zenphoto_Authority {
 					}
 				}
 
-				$sql = 'UPDATE '.prefix('administrators').' SET `rights`='.$newrights.' WHERE `id`='.$user['id'];
+				$sql = 'UPDATE ' . prefix('administrators') . ' SET `rights`=' . $newrights . ' WHERE `id`=' . $user['id'];
 				$success = $success && query($sql);
 			} // end loop
 			db_free_result($admins);
@@ -424,12 +465,13 @@ class Zenphoto_Authority {
 	 */
 	static function updateAdminField($update, $value, $constraints) {
 		$where = '';
-		foreach ($constraints as $field=>$clause) {
-			if (!empty($where)) $where .= ' AND ';
+		foreach ($constraints as $field => $clause) {
+			if (!empty($where))
+				$where .= ' AND ';
 			if (is_numeric($clause)) {
-				$where .= $field.$clause;
+				$where .= $field . $clause;
 			} else {
-				$where .= $field.db_quote($clause);
+				$where .= $field . db_quote($clause);
 			}
 		}
 		if (is_null($value)) {
@@ -437,7 +479,7 @@ class Zenphoto_Authority {
 		} else {
 			$value = db_quote($value);
 		}
-		$sql = 'UPDATE '.prefix('administrators').' SET `'.$update.'`='.$value.' WHERE '.$where;
+		$sql = 'UPDATE ' . prefix('administrators') . ' SET `' . $update . '`=' . $value . ' WHERE ' . $where;
 		$result = query($sql);
 		return $result;
 	}
@@ -448,7 +490,7 @@ class Zenphoto_Authority {
 	 * @param $valid
 	 * @return object
 	 */
-	static function newAdministrator($name, $valid=1) {
+	static function newAdministrator($name, $valid = 1) {
 		$user = new Zenphoto_Administrator($name, $valid);
 		return $user;
 	}
@@ -458,7 +500,7 @@ class Zenphoto_Authority {
 	 *
 	 * @param $version
 	 */
-	static function getRights($version=NULL) {
+	static function getRights($version = NULL) {
 		if (empty($version)) {
 			$v = self::getVersion();
 		} else {
@@ -466,127 +508,114 @@ class Zenphoto_Authority {
 		}
 		switch ($v) {
 			case 1:
-				$rightsset = array(	'NO_RIGHTS' => array('value'=>2,'name'=>gettext('No rights'),'set'=>'','display'=>false,'hint'=>''),
-														'OVERVIEW_RIGHTS' => array('value'=>4,'name'=>gettext('Overview'),'set'=>'','display'=>true,'hint'=>''),
-														'VIEW_ALL_RIGHTS' => array('value'=>8,'name'=>gettext('View all'),'set'=>'','display'=>true,'hint'=>''),
-														'UPLOAD_RIGHTS' => array('value'=>16,'name'=>gettext('Upload'),'set'=>'','display'=>true,'hint'=>''),
-														'POST_COMMENT_RIGHTS'=> array('value'=>32,'name'=>gettext('Post comments'),'set'=>'','display'=>true,'hint'=>''),
-														'COMMENT_RIGHTS' => array('value'=>64,'name'=>gettext('Comments'),'set'=>'','display'=>true,'hint'=>''),
-														'ALBUM_RIGHTS' => array('value'=>256,'name'=>gettext('Album'),'set'=>'','display'=>true,'hint'=>''),
-														'MANAGE_ALL_ALBUM_RIGHTS' => array('value'=>512,'name'=>gettext('Manage all albums'),'set'=>'','display'=>true,'hint'=>''),
-														'THEMES_RIGHTS' => array('value'=>1024,'name'=>gettext('Themes'),'set'=>'','display'=>true,'hint'=>''),
-														'ZENPAGE_RIGHTS' => array('value'=>2049,'name'=>gettext('Zenpage'),'set'=>'','display'=>true,'hint'=>''),
-														'TAGS_RIGHTS' => array('value'=>4096,'name'=>gettext('Tags'),'set'=>'','display'=>true,'hint'=>''),
-														'OPTIONS_RIGHTS' => array('value'=>8192,'name'=>gettext('Options'),'set'=>'','display'=>true,'hint'=>''),
-														'ADMIN_RIGHTS' => array('value'=>65536,'name'=>gettext('Admin'),'set'=>'','display'=>true,'hint'=>''));
+				$rightsset = array('NO_RIGHTS'								 => array('value' => 2, 'name' => gettext('No rights'), 'set' => '', 'display' => false, 'hint' => ''),
+								'OVERVIEW_RIGHTS'					 => array('value' => 4, 'name' => gettext('Overview'), 'set' => '', 'display' => true, 'hint' => ''),
+								'VIEW_ALL_RIGHTS'					 => array('value' => 8, 'name' => gettext('View all'), 'set' => '', 'display' => true, 'hint' => ''),
+								'UPLOAD_RIGHTS'						 => array('value' => 16, 'name' => gettext('Upload'), 'set' => '', 'display' => true, 'hint' => ''),
+								'POST_COMMENT_RIGHTS'			 => array('value' => 32, 'name' => gettext('Post comments'), 'set' => '', 'display' => true, 'hint' => ''),
+								'COMMENT_RIGHTS'					 => array('value' => 64, 'name' => gettext('Comments'), 'set' => '', 'display' => true, 'hint' => ''),
+								'ALBUM_RIGHTS'						 => array('value' => 256, 'name' => gettext('Album'), 'set' => '', 'display' => true, 'hint' => ''),
+								'MANAGE_ALL_ALBUM_RIGHTS'	 => array('value' => 512, 'name' => gettext('Manage all albums'), 'set' => '', 'display' => true, 'hint' => ''),
+								'THEMES_RIGHTS'						 => array('value' => 1024, 'name' => gettext('Themes'), 'set' => '', 'display' => true, 'hint' => ''),
+								'ZENPAGE_RIGHTS'					 => array('value' => 2049, 'name' => gettext('Zenpage'), 'set' => '', 'display' => true, 'hint' => ''),
+								'TAGS_RIGHTS'							 => array('value' => 4096, 'name' => gettext('Tags'), 'set' => '', 'display' => true, 'hint' => ''),
+								'OPTIONS_RIGHTS'					 => array('value' => 8192, 'name' => gettext('Options'), 'set' => '', 'display' => true, 'hint' => ''),
+								'ADMIN_RIGHTS'						 => array('value' => 65536, 'name' => gettext('Admin'), 'set' => '', 'display' => true, 'hint' => ''));
 				break;
 			case 2:
-				$rightsset = array(	'NO_RIGHTS' => array('value'=>1,'name'=>gettext('No rights'),'set'=>'','display'=>false,'hint'=>''),
-														'OVERVIEW_RIGHTS' => array('value'=>pow(2,2),'name'=>gettext('Overview'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may view the admin overview page.')),
-														'VIEW_ALL_RIGHTS' => array('value'=>pow(2,4),'name'=>gettext('View all'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may view all of the gallery regardless of protection of the page. Without this right, the user can view only public ones and those checked in his managed object lists or as granted by View Search or View Gallery.')),
-														'UPLOAD_RIGHTS' => array('value'=>pow(2,6),'name'=>gettext('Upload'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may upload to the albums for which they have management rights.')),
-														'POST_COMMENT_RIGHTS'=> array('value'=>pow(2,8),'name'=>gettext('Post comments'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('When the comment_form plugin is used for comments and its "Only members can comment" option is set, only users with this right may post comments.')),
-														'COMMENT_RIGHTS' => array('value'=>pow(2,10),'name'=>gettext('Comments'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make comments tab changes.')),
-														'ALBUM_RIGHTS' => array('value'=>pow(2,12),'name'=>gettext('Albums'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right may access the "albums" tab to make changes.')),
-														'ZENPAGE_PAGES_RIGHTS' => array('value'=>pow(2,14),'name'=>gettext('Pages'),'set'=>gettext('Pages'),'display'=>true,'hint'=>gettext('Users with this right may edit and manage Zenpage pages.')),
-														'ZENPAGE_NEWS_RIGHTS' => array('value'=>pow(2,16),'name'=>gettext('News'),'set'=>gettext('News'),'display'=>true,'hint'=>gettext('Users with this right may edit and manage Zenpage articles and categories.')),
-														'FILES_RIGHTS' => array('value'=>pow(2,18),'name'=>gettext('Files'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Allows the user access to the "filemanager" located on the upload: files sub-tab.')),
-														'MANAGE_ALL_PAGES_RIGHTS' => array('value'=>pow(2,20),'name'=>gettext('Manage all pages'),'set'=>gettext('Pages'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage page.')),
-														'MANAGE_ALL_NEWS_RIGHTS' => array('value'=>pow(2,22),'name'=>gettext('Manage all news'),'set'=>gettext('News'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage news article or category.')),
-														'MANAGE_ALL_ALBUM_RIGHTS' => array('value'=>pow(2,24),'name'=>gettext('Manage all albums'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any album in the gallery.')),
-														'THEMES_RIGHTS' => array('value'=>pow(2,26),'name'=>gettext('Themes'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make themes related changes. These are limited to the themes associated with albums checked in their managed albums list.')),
-														'TAGS_RIGHTS' => array('value'=>pow(2,28),'name'=>gettext('Tags'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('Users with this right may make additions and changes to the set of tags.')),
-														'OPTIONS_RIGHTS' => array('value'=>pow(2,29),'name'=>gettext('Options'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('Users with this right may make changes on the options tabs.')),
-														'ADMIN_RIGHTS' => array('value'=>pow(2,30),'name'=>gettext('Admin'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('The master privilege. A user with "Admin" can do anything. (No matter what his other rights might indicate!)')));
+				$rightsset = array('NO_RIGHTS'								 => array('value' => 1, 'name' => gettext('No rights'), 'set' => '', 'display' => false, 'hint' => ''),
+								'OVERVIEW_RIGHTS'					 => array('value' => pow(2, 2), 'name' => gettext('Overview'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may view the admin overview page.')),
+								'VIEW_ALL_RIGHTS'					 => array('value' => pow(2, 4), 'name' => gettext('View all'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may view all of the gallery regardless of protection of the page. Without this right, the user can view only public ones and those checked in his managed object lists or as granted by View Search or View Gallery.')),
+								'UPLOAD_RIGHTS'						 => array('value' => pow(2, 6), 'name' => gettext('Upload'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may upload to the albums for which they have management rights.')),
+								'POST_COMMENT_RIGHTS'			 => array('value' => pow(2, 8), 'name' => gettext('Post comments'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('When the comment_form plugin is used for comments and its "Only members can comment" option is set, only users with this right may post comments.')),
+								'COMMENT_RIGHTS'					 => array('value' => pow(2, 10), 'name' => gettext('Comments'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make comments tab changes.')),
+								'ALBUM_RIGHTS'						 => array('value' => pow(2, 12), 'name' => gettext('Albums'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right may access the “albums” tab to make changes.')),
+								'ZENPAGE_PAGES_RIGHTS'		 => array('value' => pow(2, 14), 'name' => gettext('Pages'), 'set' => gettext('Pages'), 'display' => true, 'hint' => gettext('Users with this right may edit and manage Zenpage pages.')),
+								'ZENPAGE_NEWS_RIGHTS'			 => array('value' => pow(2, 16), 'name' => gettext('News'), 'set' => gettext('News'), 'display' => true, 'hint' => gettext('Users with this right may edit and manage Zenpage articles and categories.')),
+								'FILES_RIGHTS'						 => array('value' => pow(2, 18), 'name' => gettext('Files'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Allows the user access to the “filemanager” located on the upload: files sub-tab.')),
+								'MANAGE_ALL_PAGES_RIGHTS'	 => array('value' => pow(2, 20), 'name' => gettext('Manage all pages'), 'set' => gettext('Pages'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage page.')),
+								'MANAGE_ALL_NEWS_RIGHTS'	 => array('value' => pow(2, 22), 'name' => gettext('Manage all news'), 'set' => gettext('News'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage news article or category.')),
+								'MANAGE_ALL_ALBUM_RIGHTS'	 => array('value' => pow(2, 24), 'name' => gettext('Manage all albums'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any album in the gallery.')),
+								'THEMES_RIGHTS'						 => array('value' => pow(2, 26), 'name' => gettext('Themes'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make themes related changes. These are limited to the themes associated with albums checked in their managed albums list.')),
+								'TAGS_RIGHTS'							 => array('value' => pow(2, 28), 'name' => gettext('Tags'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users with this right may make additions and changes to the set of tags.')),
+								'OPTIONS_RIGHTS'					 => array('value' => pow(2, 29), 'name' => gettext('Options'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users with this right may make changes on the options tabs.')),
+								'ADMIN_RIGHTS'						 => array('value' => pow(2, 30), 'name' => gettext('Admin'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('The master privilege. A user with "Admin" can do anything. (No matter what his other rights might indicate!)')));
 				break;
 			case 3:
-				$rightsset = array(	'NO_RIGHTS' => array('value'=>1,'name'=>gettext('No rights'),'set'=>'','display'=>false,'hint'=>''),
-
-														'OVERVIEW_RIGHTS' => array('value'=>pow(2,2),'name'=>gettext('Overview'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('Users with this right may view the admin overview page.')),
-
-														'VIEW_GALLERY_RIGHTS' => array('value'=>pow(2,4),'name'=>gettext('View gallery'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may view otherwise protected generic gallery pages.')),
-														'VIEW_SEARCH_RIGHTS' => array('value'=>pow(2,5),'name'=>gettext('View search'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may view search pages even if password protected.')),
-														'VIEW_FULLIMAGE_RIGHTS' => array('value'=>pow(2,6),'name'=>gettext('View fullimage'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right may view all full sized (raw) images.')),
-														'ALL_NEWS_RIGHTS' => array('value'=>pow(2,7),'name'=>gettext('Access all'),'set'=>gettext('News'),'display'=>true,'hint'=>gettext('Users with this right have access to all zenpage news articles.')),
-														'ALL_PAGES_RIGHTS' => array('value'=>pow(2,8),'name'=>gettext('Access all'),'set'=>gettext('Pages'),'display'=>true,'hint'=>gettext('Users with this right have access to all zenpage pages.')),
-														'ALL_ALBUMS_RIGHTS' => array('value'=>pow(2,9),'name'=>gettext('Access all'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right have access to all albums.')),
-														'VIEW_UNPUBLISHED_RIGHTS' => array('value'=>pow(2,10),'name'=>gettext('View unpublished'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right will see all unpublished items.')),
-
-														'POST_COMMENT_RIGHTS'=> array('value'=>pow(2,11),'name'=>gettext('Post comments'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('When the comment_form plugin is used for comments and its "Only members can comment" option is set, only users with this right may post comments.')),
-														'COMMENT_RIGHTS' => array('value'=>pow(2,12),'name'=>gettext('Comments'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make comments tab changes.')),
-														'UPLOAD_RIGHTS' => array('value'=>pow(2,13),'name'=>gettext('Upload'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right may upload to the albums for which they have management rights.')),
-
-														'ZENPAGE_NEWS_RIGHTS' => array('value'=>pow(2,15),'name'=>gettext('News'),'set'=>gettext('News'),'display'=>false,'hint'=>gettext('Users with this right may edit and manage Zenpage articles and categories.')),
-														'ZENPAGE_PAGES_RIGHTS' => array('value'=>pow(2,16),'name'=>gettext('Pages'),'set'=>gettext('Pages'),'display'=>false,'hint'=>gettext('Users with this right may edit and manage Zenpage pages.')),
-														'FILES_RIGHTS' => array('value'=>pow(2,17),'name'=>gettext('Files'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Allows the user access to the "filemanager" located on the upload: files sub-tab.')),
-														'ALBUM_RIGHTS' => array('value'=>pow(2,18),'name'=>gettext('Albums'),'set'=>gettext('Albums'),'display'=>false,'hint'=>gettext('Users with this right may access the "albums" tab to make changes.')),
-
-														'MANAGE_ALL_NEWS_RIGHTS' => array('value'=>pow(2,21),'name'=>gettext('Manage all'),'set'=>gettext('News'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage news article or category.')),
-														'MANAGE_ALL_PAGES_RIGHTS' => array('value'=>pow(2,22),'name'=>gettext('Manage all'),'set'=>gettext('Pages'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage page.')),
-														'MANAGE_ALL_ALBUM_RIGHTS' => array('value'=>pow(2,23),'name'=>gettext('Manage all'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any album in the gallery.')),
-
-														'THEMES_RIGHTS' => array('value'=>pow(2,26),'name'=>gettext('Themes'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make themes related changes. These are limited to the themes associated with albums checked in their managed albums list.')),
-
-														'TAGS_RIGHTS' => array('value'=>pow(2,28),'name'=>gettext('Tags'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make additions and changes to the set of tags.')),
-														'OPTIONS_RIGHTS' => array('value'=>pow(2,29),'name'=>gettext('Options'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('Users with this right may make changes on the options tabs.')),
-														'ADMIN_RIGHTS' => array('value'=>pow(2,30),'name'=>gettext('Admin'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('The master privilege. A user with "Admin" can do anything. (No matter what his other rights might indicate!)')));
+				$rightsset = array('NO_RIGHTS'								 => array('value' => 1, 'name' => gettext('No rights'), 'set' => '', 'display' => false, 'hint' => ''),
+								'OVERVIEW_RIGHTS'					 => array('value' => pow(2, 2), 'name' => gettext('Overview'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users with this right may view the admin overview page.')),
+								'VIEW_GALLERY_RIGHTS'			 => array('value' => pow(2, 4), 'name' => gettext('View gallery'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may view otherwise protected generic gallery pages.')),
+								'VIEW_SEARCH_RIGHTS'			 => array('value' => pow(2, 5), 'name' => gettext('View search'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may view search pages even if password protected.')),
+								'VIEW_FULLIMAGE_RIGHTS'		 => array('value' => pow(2, 6), 'name' => gettext('View fullimage'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right may view all full sized (raw) images.')),
+								'ALL_NEWS_RIGHTS'					 => array('value' => pow(2, 7), 'name' => gettext('Access all'), 'set' => gettext('News'), 'display' => true, 'hint' => gettext('Users with this right have access to all zenpage news articles.')),
+								'ALL_PAGES_RIGHTS'				 => array('value' => pow(2, 8), 'name' => gettext('Access all'), 'set' => gettext('Pages'), 'display' => true, 'hint' => gettext('Users with this right have access to all zenpage pages.')),
+								'ALL_ALBUMS_RIGHTS'				 => array('value' => pow(2, 9), 'name' => gettext('Access all'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right have access to all albums.')),
+								'VIEW_UNPUBLISHED_RIGHTS'	 => array('value' => pow(2, 10), 'name' => gettext('View unpublished'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right will see all unpublished items.')),
+								'POST_COMMENT_RIGHTS'			 => array('value' => pow(2, 11), 'name' => gettext('Post comments'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('When the comment_form plugin is used for comments and its "Only members can comment" option is set, only users with this right may post comments.')),
+								'COMMENT_RIGHTS'					 => array('value' => pow(2, 12), 'name' => gettext('Comments'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make comments tab changes.')),
+								'UPLOAD_RIGHTS'						 => array('value' => pow(2, 13), 'name' => gettext('Upload'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right may upload to the albums for which they have management rights.')),
+								'ZENPAGE_NEWS_RIGHTS'			 => array('value' => pow(2, 15), 'name' => gettext('News'), 'set' => gettext('News'), 'display' => false, 'hint' => gettext('Users with this right may edit and manage Zenpage articles and categories.')),
+								'ZENPAGE_PAGES_RIGHTS'		 => array('value' => pow(2, 16), 'name' => gettext('Pages'), 'set' => gettext('Pages'), 'display' => false, 'hint' => gettext('Users with this right may edit and manage Zenpage pages.')),
+								'FILES_RIGHTS'						 => array('value' => pow(2, 17), 'name' => gettext('Files'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Allows the user access to the “filemanager” located on the upload: files sub-tab.')),
+								'ALBUM_RIGHTS'						 => array('value' => pow(2, 18), 'name' => gettext('Albums'), 'set' => gettext('Albums'), 'display' => false, 'hint' => gettext('Users with this right may access the “albums” tab to make changes.')),
+								'MANAGE_ALL_NEWS_RIGHTS'	 => array('value' => pow(2, 21), 'name' => gettext('Manage all'), 'set' => gettext('News'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage news article or category.')),
+								'MANAGE_ALL_PAGES_RIGHTS'	 => array('value' => pow(2, 22), 'name' => gettext('Manage all'), 'set' => gettext('Pages'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage page.')),
+								'MANAGE_ALL_ALBUM_RIGHTS'	 => array('value' => pow(2, 23), 'name' => gettext('Manage all'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any album in the gallery.')),
+								'THEMES_RIGHTS'						 => array('value' => pow(2, 26), 'name' => gettext('Themes'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make themes related changes. These are limited to the themes associated with albums checked in their managed albums list.')),
+								'TAGS_RIGHTS'							 => array('value' => pow(2, 28), 'name' => gettext('Tags'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make additions and changes to the set of tags.')),
+								'OPTIONS_RIGHTS'					 => array('value' => pow(2, 29), 'name' => gettext('Options'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users with this right may make changes on the options tabs.')),
+								'ADMIN_RIGHTS'						 => array('value' => pow(2, 30), 'name' => gettext('Admin'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('The master privilege. A user with "Admin" can do anything. (No matter what his other rights might indicate!)')));
 				break;
 			case 4:
-				$rightsset = array(	'NO_RIGHTS' => array('value'=>1,'name'=>gettext('No rights'),'set'=>'','display'=>false,'hint'=>''),
-
-														'OVERVIEW_RIGHTS' => array('value'=>pow(2,2),'name'=>gettext('Overview'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('Users with this right may view the admin overview page.')),
-														'USER_RIGHTS' => array('value'=>pow(2,3),'name'=>gettext('User'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('Users must have this right to change their credentials.')),
-
-														'VIEW_GALLERY_RIGHTS' => array('value'=>pow(2,5),'name'=>gettext('View gallery'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may view otherwise protected generic gallery pages.')),
-														'VIEW_SEARCH_RIGHTS' => array('value'=>pow(2,6),'name'=>gettext('View search'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may view search pages even if password protected.')),
-														'VIEW_FULLIMAGE_RIGHTS' => array('value'=>pow(2,7),'name'=>gettext('View fullimage'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right may view all full sized (raw) images.')),
-														'ALL_NEWS_RIGHTS' => array('value'=>pow(2,8),'name'=>gettext('Access all'),'set'=>gettext('News'),'display'=>true,'hint'=>gettext('Users with this right have access to all zenpage news articles.')),
-														'ALL_PAGES_RIGHTS' => array('value'=>pow(2,9),'name'=>gettext('Access all'),'set'=>gettext('Pages'),'display'=>true,'hint'=>gettext('Users with this right have access to all zenpage pages.')),
-														'ALL_ALBUMS_RIGHTS' => array('value'=>pow(2,10),'name'=>gettext('Access all'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right have access to all albums.')),
-														'VIEW_UNPUBLISHED_RIGHTS' => array('value'=>pow(2,11),'name'=>gettext('View unpublished'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right will see all unpublished items.')),
-
-														'POST_COMMENT_RIGHTS'=> array('value'=>pow(2,13),'name'=>gettext('Post comments'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('When the comment_form plugin is used for comments and its "Only members can comment" option is set, only users with this right may post comments.')),
-														'COMMENT_RIGHTS' => array('value'=>pow(2,14),'name'=>gettext('Comments'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make comments tab changes.')),
-														'UPLOAD_RIGHTS' => array('value'=>pow(2,15),'name'=>gettext('Upload'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users with this right may upload to the albums for which they have management rights.')),
-
-														'ZENPAGE_NEWS_RIGHTS' => array('value'=>pow(2,17),'name'=>gettext('News'),'set'=>gettext('News'),'display'=>false,'hint'=>gettext('Users with this right may edit and manage Zenpage articles and categories.')),
-														'ZENPAGE_PAGES_RIGHTS' => array('value'=>pow(2,18),'name'=>gettext('Pages'),'set'=>gettext('Pages'),'display'=>false,'hint'=>gettext('Users with this right may edit and manage Zenpage pages.')),
-														'FILES_RIGHTS' => array('value'=>pow(2,19),'name'=>gettext('Files'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Allows the user access to the "filemanager" located on the upload: files sub-tab.')),
-														'ALBUM_RIGHTS' => array('value'=>pow(2,20),'name'=>gettext('Albums'),'set'=>gettext('Albums'),'display'=>false,'hint'=>gettext('Users with this right may access the "albums" tab to make changes.')),
-
-														'MANAGE_ALL_NEWS_RIGHTS' => array('value'=>pow(2,21),'name'=>gettext('Manage all'),'set'=>gettext('News'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage news article or category.')),
-														'MANAGE_ALL_PAGES_RIGHTS' => array('value'=>pow(2,22),'name'=>gettext('Manage all'),'set'=>gettext('Pages'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage page.')),
-														'MANAGE_ALL_ALBUM_RIGHTS' => array('value'=>pow(2,23),'name'=>gettext('Manage all'),'set'=>gettext('Albums'),'display'=>true,'hint'=>gettext('Users who do not have "Admin" rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any album in the gallery.')),
-
-														'THEMES_RIGHTS' => array('value'=>pow(2,26),'name'=>gettext('Themes'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make themes related changes. These are limited to the themes associated with albums checked in their managed albums list.')),
-
-														'TAGS_RIGHTS' => array('value'=>pow(2,28),'name'=>gettext('Tags'),'set'=>gettext('Gallery'),'display'=>true,'hint'=>gettext('Users with this right may make additions and changes to the set of tags.')),
-														'OPTIONS_RIGHTS' => array('value'=>pow(2,29),'name'=>gettext('Options'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('Users with this right may make changes on the options tabs.')),
-														'ADMIN_RIGHTS' => array('value'=>pow(2,30),'name'=>gettext('Admin'),'set'=>gettext('General'),'display'=>true,'hint'=>gettext('The master privilege. A user with "Admin" can do anything. (No matter what his other rights might indicate!)')));
+				$rightsset = array('NO_RIGHTS'								 => array('value' => 1, 'name' => gettext('No rights'), 'set' => '', 'display' => false, 'hint' => ''),
+								'OVERVIEW_RIGHTS'					 => array('value' => pow(2, 2), 'name' => gettext('Overview'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users with this right may view the admin overview page.')),
+								'USER_RIGHTS'							 => array('value' => pow(2, 3), 'name' => gettext('User'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users must have this right to change their credentials.')),
+								'VIEW_GALLERY_RIGHTS'			 => array('value' => pow(2, 5), 'name' => gettext('View gallery'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may view otherwise protected generic gallery pages.')),
+								'VIEW_SEARCH_RIGHTS'			 => array('value' => pow(2, 6), 'name' => gettext('View search'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may view search pages even if password protected.')),
+								'VIEW_FULLIMAGE_RIGHTS'		 => array('value' => pow(2, 7), 'name' => gettext('View fullimage'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right may view all full sized (raw) images.')),
+								'ALL_NEWS_RIGHTS'					 => array('value' => pow(2, 8), 'name' => gettext('Access all'), 'set' => gettext('News'), 'display' => true, 'hint' => gettext('Users with this right have access to all zenpage news articles.')),
+								'ALL_PAGES_RIGHTS'				 => array('value' => pow(2, 9), 'name' => gettext('Access all'), 'set' => gettext('Pages'), 'display' => true, 'hint' => gettext('Users with this right have access to all zenpage pages.')),
+								'ALL_ALBUMS_RIGHTS'				 => array('value' => pow(2, 10), 'name' => gettext('Access all'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right have access to all albums.')),
+								'VIEW_UNPUBLISHED_RIGHTS'	 => array('value' => pow(2, 11), 'name' => gettext('View unpublished'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right will see all unpublished items.')),
+								'POST_COMMENT_RIGHTS'			 => array('value' => pow(2, 13), 'name' => gettext('Post comments'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('When the comment_form plugin is used for comments and its "Only members can comment" option is set, only users with this right may post comments.')),
+								'COMMENT_RIGHTS'					 => array('value' => pow(2, 14), 'name' => gettext('Comments'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make comments tab changes.')),
+								'UPLOAD_RIGHTS'						 => array('value' => pow(2, 15), 'name' => gettext('Upload'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users with this right may upload to the albums for which they have management rights.')),
+								'ZENPAGE_NEWS_RIGHTS'			 => array('value' => pow(2, 17), 'name' => gettext('News'), 'set' => gettext('News'), 'display' => false, 'hint' => gettext('Users with this right may edit and manage Zenpage articles and categories.')),
+								'ZENPAGE_PAGES_RIGHTS'		 => array('value' => pow(2, 18), 'name' => gettext('Pages'), 'set' => gettext('Pages'), 'display' => false, 'hint' => gettext('Users with this right may edit and manage Zenpage pages.')),
+								'FILES_RIGHTS'						 => array('value' => pow(2, 19), 'name' => gettext('Files'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Allows the user access to the “filemanager” located on the upload: files sub-tab.')),
+								'ALBUM_RIGHTS'						 => array('value' => pow(2, 20), 'name' => gettext('Albums'), 'set' => gettext('Albums'), 'display' => false, 'hint' => gettext('Users with this right may access the “albums” tab to make changes.')),
+								'MANAGE_ALL_NEWS_RIGHTS'	 => array('value' => pow(2, 21), 'name' => gettext('Manage all'), 'set' => gettext('News'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage news article or category.')),
+								'MANAGE_ALL_PAGES_RIGHTS'	 => array('value' => pow(2, 22), 'name' => gettext('Manage all'), 'set' => gettext('Pages'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any Zenpage page.')),
+								'MANAGE_ALL_ALBUM_RIGHTS'	 => array('value' => pow(2, 23), 'name' => gettext('Manage all'), 'set' => gettext('Albums'), 'display' => true, 'hint' => gettext('Users who do not have “Admin” rights normally are restricted to manage only objects to which they have been assigned. This right allows them to manage any album in the gallery.')),
+								'CODEBLOCK_RIGHTS'				 => array('value' => pow(2, 25), 'name' => gettext('Codeblock'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users with this right may edit Codeblocks.')),
+								'THEMES_RIGHTS'						 => array('value' => pow(2, 26), 'name' => gettext('Themes'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make themes related changes. These are limited to the themes associated with albums checked in their managed albums list.')),
+								'TAGS_RIGHTS'							 => array('value' => pow(2, 28), 'name' => gettext('Tags'), 'set' => gettext('Gallery'), 'display' => true, 'hint' => gettext('Users with this right may make additions and changes to the set of tags.')),
+								'OPTIONS_RIGHTS'					 => array('value' => pow(2, 29), 'name' => gettext('Options'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('Users with this right may make changes on the options tabs.')),
+								'ADMIN_RIGHTS'						 => array('value' => pow(2, 30), 'name' => gettext('Admin'), 'set' => gettext('General'), 'display' => true, 'hint' => gettext('The master privilege. A user with "Admin" can do anything. (No matter what his other rights might indicate!)')));
 				break;
 		}
 		$allrights = 0;
-		foreach ($rightsset as $key=>$right) {
+		foreach ($rightsset as $key => $right) {
 			$allrights = $allrights | $right['value'];
 		}
-		$rightsset['ALL_RIGHTS'] =	array('value'=>$allrights,'name'=>gettext('All rights'),'display'=>false);
-		$rightsset['DEFAULT_RIGHTS'] =	array('value'=>$rightsset['OVERVIEW_RIGHTS']['value']+$rightsset['POST_COMMENT_RIGHTS']['value'],'name'=>gettext('Default rights'),'display'=>false);
+		$rightsset['ALL_RIGHTS'] = array('value' => $allrights, 'name' => gettext('All rights'), 'display' => false);
+		$rightsset['DEFAULT_RIGHTS'] = array('value' => $rightsset['OVERVIEW_RIGHTS']['value'] + $rightsset['POST_COMMENT_RIGHTS']['value'], 'name' => gettext('Default rights'), 'display' => false);
 		if (isset($rightsset['VIEW_ALL_RIGHTS']['value'])) {
-			$rightsset['DEFAULT_RIGHTS']['value'] = $rightsset['DEFAULT_RIGHTS']['value']|$rightsset['VIEW_ALL_RIGHTS']['value'];
+			$rightsset['DEFAULT_RIGHTS']['value'] = $rightsset['DEFAULT_RIGHTS']['value'] | $rightsset['VIEW_ALL_RIGHTS']['value'];
 		} else {
-			$rightsset['DEFAULT_RIGHTS']['value'] = $rightsset['DEFAULT_RIGHTS']|$rightsset['ALL_ALBUMS_RIGHTS']['value']|
-																		 $rightsset['ALL_PAGES_RIGHTS']['value']|$rightsset['ALL_NEWS_RIGHTS']['value']|
-																		 $rightsset['VIEW_SEARCH_RIGHTS']['value']|$rightsset['VIEW_GALLERY_RIGHTS']['value'];
+			$rightsset['DEFAULT_RIGHTS']['value'] = $rightsset['DEFAULT_RIGHTS'] | $rightsset['ALL_ALBUMS_RIGHTS']['value'] |
+							$rightsset['ALL_PAGES_RIGHTS']['value'] | $rightsset['ALL_NEWS_RIGHTS']['value'] |
+							$rightsset['VIEW_SEARCH_RIGHTS']['value'] | $rightsset['VIEW_GALLERY_RIGHTS']['value'];
 		}
-		$rightsset = sortMultiArray($rightsset,'value',true,false,false);
+		$rightsset = sortMultiArray($rightsset, 'value', true, false, false);
 		return $rightsset;
 	}
 
 	static function getResetTicket($user, $pass) {
 		$req = time();
 		$ref = sha1($req . $user . $pass);
-		$time = bin2hex(rc4('ticket'.HASH_SEED, $req));
-		return $time.$ref;
+		$time = bin2hex(rc4('ticket' . HASH_SEED, $req));
+		return $time . $ref;
 	}
 
 	function validateTicket($ticket, $user) {
@@ -595,7 +624,7 @@ class Zenphoto_Authority {
 		foreach ($admins as $tuser) {
 			if ($tuser['user'] == $user) {
 				if ($tuser['rights'] & USER_RIGHTS) {
-					$request_date = rc4('ticket'.HASH_SEED, pack("H*", $time = substr($ticket,0,20)));
+					$request_date = rc4('ticket' . HASH_SEED, pack("H*", $time = substr($ticket, 0, 20)));
 					$ticket = substr($ticket, 20);
 					$ref = sha1($request_date . $user . $tuser['pass']);
 					if ($ref === $ticket) {
@@ -613,13 +642,13 @@ class Zenphoto_Authority {
 
 	/**
 	 * Set log-in cookie for a user
-	 * @param string $user
+	 * @param object $user
 	 */
 	static function logUser($user) {
 		$user->set('lastloggedin', $user->get('loggedin'));
-		$user->set('loggedin',date('Y-m-d H:i:s'));
+		$user->set('loggedin', date('Y-m-d H:i:s'));
 		$user->save();
-		zp_setCookie("zp_user_auth", $user->getPass().'.'.$user->getID(), NULL, NULL, secureServer());
+		zp_setCookie("zp_user_auth", $user->getPass() . '.' . $user->getID(), NULL, NULL, secureServer());
 	}
 
 	/**
@@ -629,7 +658,7 @@ class Zenphoto_Authority {
 		global $_zp_current_admin_obj, $_zp_login_error, $_zp_captcha, $_zp_loggedin;
 		if (isset($_POST['login'])) {
 			$post_user = sanitize(@$_POST['user']);
-			$post_pass = sanitize(@$_POST['pass'],0);
+			$post_pass = sanitize(@$_POST['pass'], 0);
 			$_zp_loggedin = false;
 
 			switch (@$_POST['password']) {
@@ -653,7 +682,7 @@ class Zenphoto_Authority {
 						}
 						$_zp_current_admin_obj = $user;
 					} else {
-						zp_clearCookie("zp_user_auth");	// Clear the cookie, just in case
+						zp_clearCookie("zp_user_auth"); // Clear the cookie, just in case
 						$_zp_login_error = 1;
 					}
 					break;
@@ -663,25 +692,25 @@ class Zenphoto_Authority {
 						$info = $user->getChallengePhraseInfo();
 						if ($post_pass && $info['response'] == $post_pass) {
 							$ref = self::getResetTicket($post_user, $user->getPass());
-							header('location:'.WEBPATH.'/'.ZENFOLDER.'/admin-users.php?ticket='.$ref.'&user='.$post_user);
+							header('location:' . WEBPATH . '/' . ZENFOLDER . '/admin-users.php?ticket=' . $ref . '&user=' . $post_user);
 							exitZP();
 						}
 					}
-					$_zp_login_error = gettext('Sorry, that is not the answer.');
+					if ( !empty($info['challenge']) && !empty($_POST['pass'])) { $_zp_login_error = gettext('Sorry, that is not the answer.'); }
 					$_REQUEST['logon_step'] = 'challenge';
 					break;
 				case 'captcha':
-					if ($_zp_captcha->checkCaptcha(trim(@$_POST['code']), sanitize(@$_POST['code_h'],3))) {
-                                                require_once(dirname(__FILE__).'/../../zp-core/load_objectClasses.php'); // be sure that the plugins are loaded for the mail handler
+					if ($_zp_captcha->checkCaptcha(trim(@$_POST['code']), sanitize(@$_POST['code_h'], 3))) {
+						require_once(dirname(__FILE__).'/../../zp-core/load_objectClasses.php'); // be sure that the plugins are loaded for the mail handler
 						if (empty($post_user)) {
 							$requestor = gettext('You are receiving this e-mail because of a password reset request on your Zenphoto gallery.');
 						} else {
-							$requestor = sprintf(gettext("You are receiving this e-mail because of a password reset request on your Zenphoto gallery from a user who tried to log in as %s."),$post_user);
+							$requestor = sprintf(gettext("You are receiving this e-mail because of a password reset request on your Zenphoto gallery from a user who tried to log in as %s."), $post_user);
 						}
 						$admins = $this->getAdministrators();
 						$mails = array();
 						$user = NULL;
-						foreach ($admins as $key=>$tuser) {
+						foreach ($admins as $key => $tuser) {
 							if (!empty($tuser['email'])) {
 								if (!empty($post_user) && ($tuser['user'] == $post_user || $tuser['email'] == $post_user)) {
 									$name = $tuser['name'];
@@ -690,14 +719,14 @@ class Zenphoto_Authority {
 									}
 									$mails[$name] = $tuser['email'];
 									$user = $tuser;
-									unset($admins[$key]);	// drop him from alternate list.
+									unset($admins[$key]); // drop him from alternate list.
 								} else {
 									if (!($tuser['rights'] & ADMIN_RIGHTS)) {
-										unset($admins[$key]);	// eliminate any peons from the list
+										unset($admins[$key]); // eliminate any peons from the list
 									}
 								}
 							} else {
-								unset($admins[$key]);	// we want to ignore groups and users with no email address here!
+								unset($admins[$key]); // we want to ignore groups and users with no email address here!
 							}
 						}
 
@@ -718,9 +747,9 @@ class Zenphoto_Authority {
 							$_zp_login_error = gettext('There was no one to which to send the reset request.');
 						} else {
 							$ref = self::getResetTicket($user['user'], $user['pass']);
-							$msg = "\n".$requestor.
-									"\n".sprintf(gettext("To reset your Zenphoto Admin passwords visit: %s"),FULLWEBPATH."/".ZENFOLDER."/admin-users.php?ticket=$ref&user=".$user['user']) .
-									"\n".gettext("If you do not wish to reset your passwords just ignore this message. This ticket will automatically expire in 3 days.");
+							$msg = "\n" . $requestor .
+											"\n" . sprintf(gettext("To reset your Zenphoto Admin passwords visit: %s"), FULLWEBPATH . "/" . ZENFOLDER . "/admin-users.php?ticket=$ref&user=" . $user['user']) .
+											"\n" . gettext("If you do not wish to reset your passwords just ignore this message. This ticket will automatically expire in 3 days.");
 							$err_msg = zp_mail(gettext("The Zenphoto information you requested"), $msg, $mails, $cclist);
 							if (empty($err_msg)) {
 								$_zp_login_error = 2;
@@ -753,9 +782,9 @@ class Zenphoto_Authority {
 			$candidates = $_COOKIE;
 		}
 		if (isset($_SESSION)) {
-			$candidates = array_merge($candidates,$_SESSION);
+			$candidates = array_merge($candidates, $_SESSION);
 		}
-		foreach ($candidates as $key=>$candidate) {
+		foreach ($candidates as $key => $candidate) {
 			if (strpos($key, '_auth') === false) {
 				unset($candidates[$key]);
 			}
@@ -769,7 +798,7 @@ class Zenphoto_Authority {
 	 */
 	static function handleLogout() {
 		global $_zp_loggedin, $_zp_pre_authorization, $_zp_current_admin_obj;
-		foreach (self::getAuthCookies() as $cookie=>$value) {
+		foreach (self::getAuthCookies() as $cookie => $value) {
 			zp_clearCookie($cookie);
 		}
 		$_zp_loggedin = false;
@@ -781,9 +810,9 @@ class Zenphoto_Authority {
 	 * Checks saved cookies to see if a user is logged in
 	 */
 	function checkCookieCredentials() {
-		list($auth, $id) = explode('.',zp_getCookie('zp_user_auth').'.');
+		list($auth, $id) = explode('.', zp_getCookie('zp_user_auth') . '.');
 		$loggedin = $this->checkAuthorization($auth, $id);
-		$loggedin = zp_apply_filter('authorization_cookie',$loggedin, $auth);
+		$loggedin = zp_apply_filter('authorization_cookie', $loggedin, $auth, $id);
 		if ($loggedin) {
 			return $loggedin;
 		} else {
@@ -802,13 +831,10 @@ class Zenphoto_Authority {
 	 * @param string $hint optional hint for the password
 	 *
 	 */
-	function printLoginForm($redirect=null, $logo=true, $showUserField=true, $showCaptcha=true, $hint='') {
+	function printLoginForm($redirect = null, $logo = true, $showUserField = true, $showCaptcha = true, $hint = '') {
 		global $_zp_login_error, $_zp_captcha, $_zp_gallery;
 		if (is_null($redirect)) {
-			$redirect = WEBPATH.'/'.ZENFOLDER.'/admin.php';
-		}
-		if (GALLERY_SECURITY!='public' || $_zp_gallery->getUserLogonField()) {
-			$showUserField = true;
+			$redirect = getRequestURI();
 		}
 
 		if (isset($_POST['user'])) {
@@ -818,37 +844,25 @@ class Zenphoto_Authority {
 		}
 		if (empty($requestor)) {
 			if (isset($_GET['ref'])) {
-				$requestor = sanitize($_GET['ref'], 0);
+				$requestor = sanitize($_GET['ref']);
 			}
 		}
-		$alt_handlers = zp_apply_filter('alt_login_handler',array());
+		$alt_handlers = zp_apply_filter('alt_login_handler', array());
 		$star = false;
 		$mails = array();
-		$info = array('challenge'=>'','response'=>'');
+		$info = array('challenge' => '', 'response' => '');
 		if (!empty($requestor)) {
 			$admin = self::getAnAdmin(array('`user`=' => $requestor, '`valid`=' => 1));
-			if (is_object($admin) && rand(0,4)) {
+			if (is_object($admin)) {
 				if ($admin->getEmail()) {
 					$star = $showCaptcha;
 				}
 				$info = $admin->getChallengePhraseInfo();
 			}
-			if (empty($info['challenge'])) {
-				$questions = array(	gettext("What is your father's middle name?"),
-														gettext("What street did your Grandmother live on?"),
-														gettext("Who was your favorite singer?"),
-														gettext("When did you first get a computer?"),
-														gettext("How much wood could a woodchuck chuck if a woodchuck could chuck wood?"),
-														gettext("What is the date of the Ides of March?")
-														);
-				$v = (int)md5($requestor);
-				$v = $v % count($questions);
-				$info = array('challenge'=>$questions[$v],'response'=>0x00);
-			}
 		}
 		if (!$star) {
 			$admins = $this->getAdministrators();
-			while (count($admins)>0) {
+			while (count($admins) > 0) {
 				$user = array_shift($admins);
 				if ($user['email']) {
 					$star = $showCaptcha;
@@ -858,214 +872,224 @@ class Zenphoto_Authority {
 		$whichForm = sanitize(@$_REQUEST['logon_step']);
 		?>
 		<div id="loginform">
-		<?php
-		if ($logo) {
-			?>
-			<p>
-				<img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/zen-logo.png" title="ZenPhoto" alt="ZenPhoto" />
-			</p>
 			<?php
-		}
-		switch ($_zp_login_error) {
-			case 1:
+			if ($logo) {
+				?>
+				<p>
+					<img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/zen-logo.png" title="ZenPhoto" alt="ZenPhoto" />
+				</p>
+				<?php
+			}
+			switch ($_zp_login_error) {
+				case 1:
 					?>
 					<div class="errorbox" id="message"><h2><?php echo gettext("There was an error logging in."); ?></h2>
-					<?php
-					if ($showUserField) {
-						echo gettext("Check your username and password and try again.");
-					} else {
-						echo gettext("Check password and try again.");
-					}
-					?>
-				</div>
-				<?php
-				break;
-			case 2:
-				?>
-				<div class="messagebox fade-message">
-				<h2><?php echo gettext("A reset request has been sent."); ?></h2>
-				</div>
-				<?php
-				break;
-			default:
-				if (!empty($_zp_login_error)) {
-					?>
-					<div class="errorbox fade-message">
-					<h2><?php echo $_zp_login_error; ?></h2>
+						<?php
+						if ($showUserField) {
+							echo gettext("Check your username and password and try again.");
+						} else {
+							echo gettext("Check password and try again.");
+						}
+						?>
 					</div>
 					<?php
-				}
-				break;
-		}
-		switch ($whichForm) {
-			case 'challenge':
-				?>
-				<form name="login" action="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/admin.php" method="post">
-					<fieldset id="logon_box">
-						<input type="hidden" name="login" value="1" />
-						<input type="hidden" name="password" value="challenge" />
-						<input type="hidden" name="redirect" value="<?php echo html_encode($redirect); ?>" />
-						<fieldset>
-							<legend><?php echo gettext('User')?></legend>
-							<input class="textfield" name="user" id="user" type="text" size="35" value="<?php echo html_encode($requestor); ?>" />
-						</fieldset>
+					break;
+				case 2:
+					?>
+					<div class="messagebox fade-message">
+						<h2><?php echo gettext("A reset request has been sent."); ?></h2>
+					</div>
+					<?php
+					break;
+				default:
+					if (!empty($_zp_login_error)) {
+						?>
+						<div class="errorbox fade-message">
+							<h2><?php echo $_zp_login_error; ?></h2>
+						</div>
 						<?php
-						if ($requestor) {
-							?>
-							<p class="logon_form_text"><?php echo gettext('Supply the correct response to the question below and you will be directed to a page where you can change your password.'); ?></p>
-							<fieldset><legend><?php echo gettext('Challenge question:')?></legend>
-								<?php
-								echo html_encode($info['challenge']);
+					}
+					break;
+			}
+			switch ($whichForm) {
+				case 'challenge':
+					?>
+					<form name="login" action="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/admin.php" method="post">
+						<fieldset id="logon_box">
+							<input type="hidden" name="login" value="1" />
+							<input type="hidden" name="password" value="challenge" />
+							<input type="hidden" name="redirect" value="<?php echo html_encode(pathurlencode($redirect)); ?>" />
+							<fieldset>
+								<legend><?php echo gettext('User') ?></legend>
+								<input class="textfield" name="user" id="user" type="text" size="35" value="<?php echo html_encode($requestor); ?>" />
+							</fieldset>
+							<?php
+							if ($requestor && $admin) {
+								if (!empty($info['challenge'])) {
 								?>
-							</fieldset>
-							<fieldset><legend><?php echo gettext('Your response')?></legend>
-								<input class="textfield" name="pass" id="pass" type="text" size="35" />
-							</fieldset>
-							<br />
-							<?php
-						} else {
+								<p class="logon_form_text"><?php echo gettext('Supply the correct response to the question below and you will be directed to a page where you can change your password.'); ?>
+								<?php if ( $admin->getEmail() ) { echo gettext('<br />You may also use the link below to request a reset by e-mail.'); } ?>
+								</p>
+								<fieldset><legend><?php echo gettext('Challenge question:') ?></legend>
+									<?php
+									echo html_encode($info['challenge']);
+									?>
+								</fieldset>
+								<fieldset><legend><?php echo gettext('Your response') ?></legend>
+									<input class="textfield" name="pass" id="pass" type="text" size="35" />
+								</fieldset>
+								<br />
+								<?php } else {
+										if ( !$admin->getEmail() ) { ?>
+											<fieldset><p class="logon_form_text errorbox"><?php echo gettext('A password reset is not possible.'); ?></p></fieldset>
+									<?php } else { ?>
+											<p class="logon_form_text"><?php echo gettext('Please request a reset by e-mail by clicking the link below.'); ?></p>
+								<?php
+									}
+								}
+							} else {
+								?>
+								<p class="logon_form_text">
+									<?php
+									echo gettext('Enter your User ID and press <code>Refresh</code> to get your challenge question and/or get a link to request a reset by e-mail.');
+									?>
+								</p>
+								<?php
+							}
 							?>
-							<p class="logon_form_text">
-							<?php
-							echo gettext('Enter your User ID and press <code>Refresh</code> to get your challenge question.');
+							<div class="buttons">
+								<button type="submit" value="<?php echo gettext("Submit"); ?>"<?php if (!$info['challenge']) echo ' disabled="disabled"'; ?> ><img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/pass.png" alt="" /><?php echo gettext("Submit"); ?></button>
+								<button type="button" value="<?php echo gettext("Refresh"); ?>" id="challenge_refresh" onclick="javascript:launchScript('<?php echo WEBPATH . '/' . ZENFOLDER; ?>/admin.php', ['logon_step=challenge', 'ref=' + $('#user').val()]);" ><img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/refresh.png" alt="" /><?php echo gettext("Refresh"); ?></button>
+								<button type="button" value="<?php echo gettext("Return"); ?>" onclick="javascript:launchScript('<?php echo WEBPATH . '/' . ZENFOLDER; ?>/admin.php', ['logon_step=', 'ref=' + $('#user').val()]);" ><img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/refresh.png" alt="" /><?php echo gettext("Return"); ?></button>
+							</div>
+							<br class="clearall" />
+						</fieldset>
+						<br />
+						<?php
+						if ( $star && (!empty($requestor) && $admin->getEmail()) ) {
 							?>
+							<p class="logon_link">
+								<a href="javascript:launchScript('<?php echo WEBPATH . '/' . ZENFOLDER; ?>/admin.php',['logon_step=captcha', 'ref='+$('#user').val()]);" >
+									<?php echo gettext('Request reset by e-mail'); ?>
+								</a>
 							</p>
 							<?php
 						}
 						?>
-						<div class="buttons">
-							<button type="submit" value="<?php echo gettext("Submit"); ?>"<?php if (!$info['challenge']) echo ' disabled="disabled"'; ?> ><img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/pass.png" alt="" /><?php echo gettext("Submit"); ?></button>
-							<button type="button" value="<?php echo gettext("Refresh"); ?>" id="challenge_refresh" onclick="javascript:launchScript('<?php echo WEBPATH.'/'.ZENFOLDER; ?>/admin.php',['logon_step=challenge', 'ref='+$('#user').val()]);" ><img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/refresh.png" alt="" /><?php echo gettext("Refresh"); ?></button>
-							<button type="button" value="<?php echo gettext("Return"); ?>" onclick="javascript:launchScript('<?php echo WEBPATH.'/'.ZENFOLDER; ?>/admin.php',['logon_step=', 'ref='+$('#user').val()]);" ><img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/refresh.png" alt="" /><?php echo gettext("Return"); ?></button>
-						</div>
-						<br clear="all" />
-					</fieldset>
-					<br />
+					</form>
 					<?php
-					if ($star) {
+					break;
+				default:
+					Zenphoto_Authority::printPasswordFormJS();
+					if (empty($alt_handlers)) {
+						$legend = gettext('Login');
+					} else {
+						?>
+						<script type="text/javascript">
+							// <!-- <![CDATA[
+							var handlers = [];
+					<?php
+					$list = '<select id="logon_choices" onchange="changeHandler(handlers[$(this).val()]);">' .
+									'<option value="0">' . html_encode(get_language_string($_zp_gallery->getTitle())) . '</option>';
+					$c = 0;
+					foreach ($alt_handlers as $handler => $details) {
+						$c++;
+						$details['params'][] = 'redirect=' . $redirect;
+						if (!empty($requestor)) {
+							$details['params'][] = 'requestor=' . $requestor;
+						}
+						echo "handlers[" . $c . "]=['" . $details['script'] . "','" . implode("','", $details['params']) . "'];";
+
+						$list .= '<option value="' . $c . '">' . $handler . '</option>';
+					}
+					$list .= '</select>';
+					$legend = sprintf(gettext('Logon using:%s'), $list);
+					?>
+							function changeHandler(handler) {
+								handler.push('user=' + $('#user').val());
+								var script = handler.shift();
+								launchScript(script, handler);
+							}
+							// ]]> -->
+						</script>
+						<?php
+					}
+					$redirect = zp_apply_filter('login_redirect_link', $redirect);
+					?>
+					<form name="login" action="<?php echo html_encode(pathurlencode($redirect)); ?>" method="post">
+						<input type="hidden" name="login" value="1" />
+						<input type="hidden" name="password" value="1" />
+						<input type="hidden" name="redirect" value="<?php echo html_encode(pathurlencode($redirect)); ?>" />
+						<fieldset id="logon_box"><legend><?php echo $legend; ?></legend>
+							<?php
+							if ($showUserField) { //	requires a "user" field
+								?>
+								<fieldset><legend><?php echo gettext("User"); ?></legend>
+									<input class="textfield" name="user" id="user" type="text" size="35" value="<?php echo html_encode($requestor); ?>" />
+								</fieldset>
+								<?php
+							}
+							?>
+							<fieldset><legend><?php echo gettext("Password"); ?></legend>
+								<input class="textfield" name="pass" id="pass" type="password" size="35" /><br />
+								<label><input type="checkbox" name="disclose_password" id="disclose_password" onclick="togglePassword('');" /><?php echo gettext('Show password') ?></label>
+							</fieldset>
+							<br />
+							<div class="buttons">
+								<button type="submit" value="<?php echo gettext("Log in"); ?>" ><img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/pass.png" alt="" /><?php echo gettext("Log in"); ?></button>
+								<button type="reset" value="<?php echo gettext("Reset"); ?>" ><img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/reset.png" alt="" /><?php echo gettext("Reset"); ?></button>
+							</div>
+							<br class="clearall" />
+						</fieldset>
+					</form>
+					<?php
+					if ($hint) {
+						echo '<p>' . $hint . '</p>';
+					}
+					if ($showUserField && OFFSET_PATH != 2) {
 						?>
 						<p class="logon_link">
-							<a href="javascript:launchScript('<?php echo WEBPATH.'/'.ZENFOLDER; ?>/admin.php',['logon_step=captcha', 'ref='+$('#user').val()]);" >
-								<?php echo gettext('Request reset by e-mail'); ?>
+							<a href="javascript:launchScript('<?php echo WEBPATH . '/' . ZENFOLDER; ?>/admin.php',['logon_step=challenge', 'ref='+$('#user').val()]);" >
+								<?php echo gettext('I forgot my <strong>User ID</strong>/<strong>Password</strong>'); ?>
 							</a>
 						</p>
 						<?php
 					}
+					break;
+				case 'captcha':
+					$captcha = $_zp_captcha->getCaptcha(NULL);
 					?>
-				</form>
-				<?php
-				break;
-			default:
-				if (empty($alt_handlers)) {
-					$legend = gettext('Login');
-				} else {
-					?>
-					<script type="text/javascript">
-						// <!-- <![CDATA[
-						var handlers = [];
-						<?php
-						$list = '<select id="logon_choices" onchange="changeHandler(handlers[$(this).val()]);">'.
-											'<option value="0">'.html_encode(get_language_string($_zp_gallery->getTitle())).'</option>';
-						$c = 0;
-						foreach ($alt_handlers as $handler=>$details) {
-							$c++;
-							$details['params'][] = 'redirect='.$redirect;
-							if (!empty($requestor)) {
-								$details['params'][] = 'requestor='.$requestor;
+					<form name="login" action="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/admin.php" method="post">
+						<?php if (isset($captcha['hidden'])) echo $captcha['hidden']; ?>
+						<input type="hidden" name="login" value="1" />
+						<input type="hidden" name="password" value="captcha" />
+						<input type="hidden" name="redirect" value="<?php echo html_encode(pathurlencode($redirect)); ?>" />
+						<fieldset id="logon_box">
+							<fieldset><legend><?php echo gettext('User'); ?></legend>
+								<input class="textfield" name="user" id="user" type="text" value="<?php echo html_encode($requestor); ?>" />
+							</fieldset>
+							<?php if (isset($captcha['html'])) echo $captcha['html']; ?>
+							<?php
+							if (isset($captcha['input'])) {
+								?>
+								<fieldset><legend><?php echo gettext("Enter CAPTCHA"); ?></legend>
+									<?php echo $captcha['input']; ?>
+								</fieldset>
+								<?php
 							}
-							echo "handlers[".$c."]=['".$details['script']."','".implode("','", $details['params'])."'];";
-
-							$list .= '<option value="'.$c.'">'.$handler.'</option>';
-						}
-						$list .= '</select>';
-						$legend = sprintf(gettext('Logon using:%s'),$list);
-						?>
-						function changeHandler(handler) {
-							handler.push('user='+$('#user').val());
-							var script = handler.shift();
-							launchScript(script,handler);
-						}
-					// ]]> -->
-					</script>
-					<?php
-				}
-				?>
-				<form name="login" action="<?php echo html_encode(getRequestURI()); ?>" method="post">
-					<input type="hidden" name="login" value="1" />
-					<input type="hidden" name="password" value="1" />
-					<input type="hidden" name="redirect" value="<?php echo html_encode($redirect); ?>" />
-					<fieldset id="logon_box"><legend><?php echo $legend; ?></legend>
-						<?php
-						if ($showUserField) {	//	requires a "user" field
 							?>
-							<fieldset><legend><?php echo gettext("User"); ?></legend>
-								<input class="textfield" name="user" id="user" type="text" size="35" value="<?php echo html_encode($requestor); ?>" />
-							</fieldset>
-							<?php
-						}
-						?>
-						<fieldset><legend><?php echo gettext("Password"); ?></legend>
-							<input class="textfield" name="pass" id="pass" type="password" size="35" /><br />
-							<label><input type="checkbox" name="disclose_password" onclick="togglePassword();" ><?php echo gettext('Show password')?></label>
+							<br />
+							<div class="buttons">
+								<button type="submit" value="<?php echo gettext("Request"); ?>" ><img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/pass.png" alt="" /><?php echo gettext("Request password reset"); ?></button>
+								<button type="button" value="<?php echo gettext("Return"); ?>" onclick="javascript:launchScript('<?php echo WEBPATH . '/' . ZENFOLDER; ?>/admin.php', ['logon_step=', 'ref=' + $('#user').val()]);" ><img src="<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/refresh.png" alt="" /><?php echo gettext("Return"); ?></button>
+							</div>
+							<br class="clearall" />
 						</fieldset>
-						<br />
-						<div class="buttons">
-							<button type="submit" value="<?php echo gettext("Log in"); ?>" ><img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/pass.png" alt="" /><?php echo gettext("Log in"); ?></button>
-							<button type="reset" value="<?php echo gettext("Reset"); ?>" ><img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/reset.png" alt="" /><?php echo gettext("Reset"); ?></button>
-						</div>
-						<br clear="all" />
-					</fieldset>
-				</form>
-				<?php
-				if ($hint) {
-					echo '<p>'.$hint.'</p>';
-				}
-				if ($showUserField && OFFSET_PATH != 2) {
-					?>
-					<p class="logon_link">
-						<a href="javascript:launchScript('<?php echo WEBPATH.'/'.ZENFOLDER; ?>/admin.php',['logon_step=challenge', 'ref='+$('#user').val()]);" >
-							<?php echo gettext('I forgot my <strong>User ID</strong>/<strong>Password</strong>'); ?>
-						</a>
-					</p>
+					</form>
 					<?php
-				}
-				break;
-			case 'captcha':
-				$captcha = $_zp_captcha->getCaptcha();
-				?>
-				<form name="login" action="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/admin.php" method="post">
-					<?php if (isset($captcha['hidden'])) echo $captcha['hidden']; ?>
-					<input type="hidden" name="login" value="1" />
-					<input type="hidden" name="password" value="captcha" />
-					<input type="hidden" name="redirect" value="<?php echo html_encode($redirect); ?>" />
-					<?php
-					?>
-					<fieldset id="logon_box">
-						<fieldset><legend><?php echo gettext('User'); ?></legend>
-							<input class="textfield" name="user" id="user" type="text" value="<?php echo html_encode($requestor); ?>" />
-						</fieldset>
-						<?php if (isset($captcha['html'])) echo $captcha['html']; ?>
-						<?php
-						if (isset($captcha['input'])) {
-							?>
-							<fieldset><legend><?php echo gettext("Enter CAPTCHA"); ?></legend>
-								<?php echo $captcha['input']; ?>
-							</fieldset>
-							<?php
-						}
-						?>
-						<br />
-						<div class="buttons">
-							<button type="submit" value="<?php echo gettext("Request"); ?>" ><img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/pass.png" alt="" /><?php echo gettext("Request password reset"); ?></button>
-							<button type="button" value="<?php echo gettext("Return"); ?>" onclick="javascript:launchScript('<?php echo WEBPATH.'/'.ZENFOLDER; ?>/admin.php',['logon_step=', 'ref='+$('#user').val()]);" ><img src="<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/refresh.png" alt="" /><?php echo gettext("Return"); ?></button>
-						</div>
-						<br clear="all" />
-					</fieldset>
-				</form>
-				<?php
-				break;
-		}
-		?>
+					break;
+			}
+			?>
 		</div>
 		<?php
 	}
@@ -1077,152 +1101,155 @@ class Zenphoto_Authority {
 	static function printPasswordFormJS() {
 		?>
 		<script type="text/javascript">
-		// <!-- <![CDATA[
-		function passwordStrength(id) {
-			var inputa = '#pass'+id;
-			var inputb = '#pass_r'+id;
-			var displaym = '#match'+id;
-			var displays = '#strength'+id;
-			var numeric = 0;
-			var inputa = '#pass'+id;
-			var special = 0;
-			var upper = 0;
-			var lower = 0;
-			var str = $(inputa).val();
-			var len = str.length;
-			var strength = 0;
-			for (c=0;c<len;c++) {
-				if (str[c].match(/[0-9]/)) {
-					numeric++;
-				} else if (str[c].match(/[^A-Za-z0-9]/)) {
-					special++;
-				} else if (str[c].toUpperCase()==str[c]) {
-					upper++;
-				} else {
-					lower++;
-				}
-			}
-			if (upper != len) {
-				upper = upper*2;
-			}
-			if (lower == len) {
-				lower = lower*0.75;
-			}
-			if (numeric != len) {
-				numeric = numeric*4;
-			}
-			if (special != len) {
-				special = special*5;
-			}
-			len = Math.max(0,(len-6)*.35);
-			strength = Math.min(30,Math.round(upper+lower+numeric+special+len));
-			if (str.length == 0) {
-				$(displays).css('color','black');
-				$(displays).html('<?php echo gettext('Password'); ?>');
-				$(inputa).css('background-image','none');
-			} else {
-				if (strength < 15) {
-					$(displays).css('color','#ff0000');
-					$(displays).html('<?php echo gettext('password strength weak'); ?>');
-				} else if (strength < 25) {
-					$(displays).css('color','#ff0000');
-					$(displays).html('<?php echo gettext('password strength good'); ?>');
-				} else {
-					$(displays).css('color','#008000');
-					$(displays).html('<?php echo gettext('password strength strong'); ?>');
-				}
-				if (strength < <?php echo (int) getOption('password_strength'); ?>) {
-					$(inputb).attr('disabled','disabled');
-					$(displays).css('color','#ff0000');
-					$(displays).html('<?php echo gettext('password strength weak'); ?>');
-				} else {
-					$(inputb).removeAttr('disabled');
-					passwordMatch(id);
-				}
-				var url = 'url(<?php echo WEBPATH.'/'.ZENFOLDER; ?>/images/strengths/strength'+strength+'.png)';
-				$(inputa).css('background-image',url);
-			}
-		}
-
-		function passwordMatch(id) {
-			var inputa = '#pass'+id;
-			var inputb = '#pass_r'+id;
-			var display = '#match'+id;
-			if ($('#disclose_password'+id).attr('checked') != 'checked') {
-				if ($(inputa).val() === $(inputb).val()) {
-					if ($(inputa).val().trim() !== '') {
-						$(display).css('color','#008000');
-						$(display).html('<?php echo gettext('passwords match'); ?>');
+			// <!-- <![CDATA[
+			function passwordStrength(id) {
+				var inputa = '#pass' + id;
+				var inputb = '#pass_r' + id;
+				var displaym = '#match' + id;
+				var displays = '#strength' + id;
+				var numeric = 0;
+				var special = 0;
+				var upper = 0;
+				var lower = 0;
+				var str = $(inputa).val();
+				var len = str.length;
+				var strength = 0;
+				for (c = 0; c < len; c++) {
+					if (str[c].match(/[0-9]/)) {
+						numeric++;
+					} else if (str[c].match(/[^A-Za-z0-9]/)) {
+						special++;
+					} else if (str[c].toUpperCase() == str[c]) {
+						upper++;
+					} else {
+						lower++;
 					}
+				}
+				if (upper != len) {
+					upper = upper * 2;
+				}
+				if (lower == len) {
+					lower = lower * 0.75;
+				}
+				if (numeric != len) {
+					numeric = numeric * 4;
+				}
+				if (special != len) {
+					special = special * 5;
+				}
+				len = Math.max(0, (len - 6) * .35);
+				strength = Math.min(30, Math.round(upper + lower + numeric + special + len));
+				if (str.length == 0) {
+					$(displays).css('color', 'black');
+					$(displays).html('<?php echo gettext('Password'); ?>');
+					$(inputa).css('background-image', 'none');
 				} else {
-					$(display).css('color','#ff0000');
-					$(display).html('<?php echo gettext('passwords do not match'); ?>');
+					if (strength < 15) {
+						$(displays).css('color', '#ff0000');
+						$(displays).html('<?php echo gettext('password strength weak'); ?>');
+					} else if (strength < 25) {
+						$(displays).css('color', '#ff0000');
+						$(displays).html('<?php echo gettext('password strength good'); ?>');
+					} else {
+						$(displays).css('color', '#008000');
+						$(displays).html('<?php echo gettext('password strength strong'); ?>');
+					}
+					if (strength < <?php echo (int) getOption('password_strength'); ?>) {
+						$(inputb).prop('disabled',true);
+						$(displays).css('color', '#ff0000');
+						$(displays).html('<?php echo gettext('password strength too weak'); ?>');
+					} else {
+      $(inputb).parent().removeClass('ui-state-disabled');
+      $(inputb).prop('disabled',false);  
+						passwordMatch(id);
+					}
+					var url = 'url(<?php echo WEBPATH . '/' . ZENFOLDER; ?>/images/strengths/strength' + strength + '.png)';
+					$(inputa).css('background-image', url);
+					$(inputa).css('background-size', '100%');
 				}
 			}
-		}
 
-		function passwordClear(id) {
-			var inputa = '#pass'+id;
-			var inputb = '#pass_r'+id;
-			if ($(inputa).val().trim() === '') {
-				$(inputa).val('');
+			function passwordMatch(id) {
+				var inputa = '#pass' + id;
+				var inputb = '#pass_r' + id;
+				var display = '#match' + id;
+				if ($('#disclose_password' + id).prop('checked')) {
+					if ($(inputa).val() === $(inputb).val()) {
+						if ($(inputa).val().trim() !== '') {
+							$(display).css('color', '#008000');
+							$(display).html('<?php echo gettext('passwords match'); ?>');
+						}
+					} else {
+						$(display).css('color', '#ff0000');
+						$(display).html('<?php echo gettext('passwords do not match'); ?>');
+					}
+				}
 			}
-			if ($(inputb).val().trim() === '') {
-				$(inputb).val('');
+
+			function passwordClear(id) {
+				var inputa = '#pass' + id;
+				var inputb = '#pass_r' + id;
+				if ($(inputa).val().trim() === '') {
+					$(inputa).val('');
+				}
+				if ($(inputb).val().trim() === '') {
+					$(inputb).val('');
+				}
 			}
-		}
-		function togglePassword(id) {
-		if($('#pass'+id).attr('type')=='password') {
-				var oldp = $('#pass'+id);
-				var newp = oldp.clone();
-				newp.attr('type', 'text');
-				newp.insertAfter(oldp);
-				oldp.remove();
-				$('.password_field_'+id).hide();
-			} else {
-				var oldp = $('#pass'+id);
-				var newp = oldp.clone();
-				newp.attr('type', 'password');
-				newp.insertAfter(oldp);
-				oldp.remove();
-				$('.password_field_'+id).show();
+			function togglePassword(id) {
+				if ($('#pass' + id).attr('type') == 'password') {
+					var oldp = $('#pass' + id);
+					var newp = oldp.clone();
+					newp.attr('type', 'text');
+					newp.insertAfter(oldp);
+					oldp.remove();
+					$('.password_field_' + id).hide();
+				} else {
+					var oldp = $('#pass' + id);
+					var newp = oldp.clone();
+					newp.attr('type', 'password');
+					newp.insertAfter(oldp);
+					oldp.remove();
+					$('.password_field_' + id).show();
+				}
 			}
-		}
-		// ]]> -->
+			// ]]> -->
 		</script>
 		<?php
 	}
 
-	static function printPasswordForm($id='', $pad=false, $disable=NULL, $required=false, $flag='') {
+	static function printPasswordForm($id = '', $pad = false, $disable = NULL, $required = false, $flag = '') {
 		if ($pad) {
 			$x = '          ';
 		} else {
 			$x = '';
 		}
-
 		?>
 		<input type="hidden" name="passrequired<?php echo $id; ?>" id="passrequired-<?php echo $id; ?>" value="<?php echo (int) $required; ?>" />
-		<fieldset>
-			<legend id="strength<?php echo $id; ?>"><?php echo gettext("Password").$flag; ?></legend>
+		<p>
+			<label for="pass<?php echo $id; ?>" id="strength<?php echo $id; ?>"><?php echo gettext("Password") . $flag; ?></label>
 			<input type="password" size="<?php echo TEXT_INPUT_SIZE; ?>"
-							name="pass<?php echo $id ?>" value="<?php echo $x; ?>"
-							id="pass<?php echo $id; ?>"
-							onchange="$('#passrequired-<?php echo $id; ?>').val(1);"
-							onclick="passwordClear('<?php echo $id; ?>');"
-							onkeyup="passwordStrength('<?php echo $id; ?>');"
-							<?php echo $disable; ?> />
-			<br clear="all" />
-			<label><input type="checkbox" name="disclose_password<?php echo $id; ?>" id="disclose_password<?php echo $id; ?>" onclick="passwordClear('<?php echo $id; ?>');togglePassword('<?php echo $id; ?>');"><?php echo gettext('Show password'); ?></label>
-		</fieldset>
-		<fieldset class="password_field_<?php echo $id; ?>">
-			<legend id="match<?php echo $id; ?>"><?php echo gettext("Repeat password").$flag; ?></legend>
+						 name="pass<?php echo $id ?>" value="<?php echo $x; ?>"
+						 id="pass<?php echo $id; ?>"
+						 onchange="$('#passrequired-<?php echo $id; ?>').val(1);"
+						 onclick="passwordClear('<?php echo $id; ?>');"
+						 onkeyup="passwordStrength('<?php echo $id; ?>');"
+						 <?php echo $disable; ?> />
+		</p>
+		<p>
+			<label for="disclose_password<?php echo $id; ?>"><?php echo gettext('Show password'); ?></label>
+			<input type="checkbox" name="disclose_password<?php echo $id; ?>" id="disclose_password<?php echo $id; ?>" onclick="passwordClear('<?php echo $id; ?>');
+					togglePassword('<?php echo $id; ?>');">
+		</p>
+		<p class="password_field_<?php echo $id; ?>">
+			<label for="pass_r<?php echo $id; ?>" id="match<?php echo $id; ?>"><?php echo gettext("Repeat password") . $flag; ?></label>
 			<input type="password" size="<?php echo TEXT_INPUT_SIZE; ?>"
-							name="pass_r<?php echo $id ?>" value="<?php echo $x; ?>"
-							id="pass_r<?php echo $id; ?>" disabled="disabled"
-							onchange="$('#passrequired-<?php echo $id; ?>').val(1);"
-							onkeydown="passwordClear('<?php echo $id; ?>');"
-							onkeyup="passwordMatch('<?php echo $id; ?>');" />
-		</fieldset>
+						 name="pass_r<?php echo $id ?>" value="<?php echo $x; ?>"
+						 id="pass_r<?php echo $id; ?>" disabled="disabled"
+						 onchange="$('#passrequired-<?php echo $id; ?>').val(1);"
+						 onkeydown="passwordClear('<?php echo $id; ?>');"
+						 onkeyup="passwordMatch('<?php echo $id; ?>');" />
+		</p>
 		<?php
 	}
 
@@ -1235,23 +1262,40 @@ class Zenphoto_Authority {
 	 *  @param string a hash algorithm
 	 *
 	 *  @return string derived key
-	*/
-	static function pbkdf2($p, $s, $c=1000, $kl=32, $a = 'sha256') {
-			$hl = strlen(hash($a, null, true)); # Hash length
-			$kb = ceil($kl / $hl);              # Key blocks to compute
-			$dk = '';                           # Derived key
-			# Create key
-			for ( $block = 1; $block <= $kb; $block ++ ) {
-					# Initial hash for this block
-					$ib = $b = hash_hmac($a, $s . pack('N', $block), $p, true);
-					# Perform block iterations
-					for ( $i = 1; $i < $c; $i ++ )
-							# XOR each iterate
-							$ib ^= ($b = hash_hmac($a, $b, $p, true));
-					$dk .= $ib; # Append iterated block
-		 }
-			# Return derived key of correct length
-			return substr($dk, 0, $kl);
+	 */
+	static function pbkdf2($p, $s, $c = 1000, $kl = 32, $a = 'sha256') {
+		$hl = strlen(hash($a, null, true)); # Hash length
+		$kb = ceil($kl / $hl); # Key blocks to compute
+		$dk = ''; # Derived key
+		# Create key
+		for ($block = 1; $block <= $kb; $block++) {
+			# Initial hash for this block
+			$ib = $b = hash_hmac($a, $s . pack('N', $block), $p, true);
+			# Perform block iterations
+			for ($i = 1; $i < $c; $i++)
+			# XOR each iterate
+				$ib ^= ($b = hash_hmac($a, $b, $p, true));
+			$dk .= $ib; # Append iterated block
+		}
+		# Return derived key of correct length
+		return substr($dk, 0, $kl);
+	}
+	
+	/**
+	 * Checks if the email address being set is already used by another user
+	 * 
+	 * @param string $email_to_check email address to check
+	 * @param type $current_user user id of the user trying to set this email address
+	 * @return boolean
+	 */
+	function checkUniqueMailaddress($email_to_check, $current_user) {
+		$all_users = $this->getAdministrators('users');
+		foreach ($all_users as $user) {
+			if ($user['user'] != $current_user && $user['email'] == $email_to_check) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 }
@@ -1266,11 +1310,11 @@ class Zenphoto_Administrator extends PersistentObject {
 	 *
 	 */
 	var $objects = NULL;
-	var $master = false;	//	will be set to true if this is the inherited master user
-	var $msg = NULL;	//	a means of storing error messages from filter processing
-	var $logout_link = true;	// for a Zenphoto logout
-	var $reset = false;	// if true the user was setup by a "reset password" event
-	var $passhash;	// the hash algorithm used in creating the password
+	var $master = false; //	will be set to true if this is the inherited master user
+	var $msg = NULL; //	a means of storing error messages from filter processing
+	var $logout_link = true; // for a Zenphoto logout
+	var $reset = false; // if true the user was setup by a "reset password" event
+	var $passhash; // the hash algorithm used in creating the password
 
 	/**
 	 * Constructor for an Administrator
@@ -1279,40 +1323,58 @@ class Zenphoto_Administrator extends PersistentObject {
 	 * @param int $valid used to signal kind of admin object
 	 * @return Administrator
 	 */
+
 	function __construct($user, $valid) {
 		global $_zp_authority;
 		$this->passhash = (int) getOption('strong_hash');
-		parent::PersistentObject('administrators', array('user' => $user, 'valid'=>$valid), NULL, false, empty($user));
+		$this->instantiate('administrators', array('user' => $user, 'valid' => $valid), NULL, false, empty($user));
 		if (empty($user)) {
 			$this->set('id', -1);
 		}
 		if ($valid) {
-			if ($user == $_zp_authority->master_user) {
-				$this->setRights($this->getRights() | ADMIN_RIGHTS);
+			$rights = $this->getRights();
+			$new_rights = 0;
+			if ($_zp_authority->isMasterUser($user)) {
+				$new_rights = ALL_RIGHTS;
 				$this->master = true;
 			} else {
 				// make sure that the "hidden" gateway rights are set for managing objects
+				if ($rights & MANAGE_ALL_ALBUM_RIGHTS) {
+					$new_rights = $new_rights | ALBUM_RIGHTS;
+				}
+				if ($rights & MANAGE_ALL_NEWS_RIGHTS) {
+					$new_rights = $new_rights | ZENPAGE_PAGES_RIGHTS;
+				}
+				if ($rights & MANAGE_ALL_PAGES_RIGHTS) {
+					$new_rights = $new_rights | ZENPAGE_NEWS_RIGHTS;
+				}
 				$this->getObjects();
 				foreach ($this->objects as $object) {
 					switch ($object['type']) {
 						case 'album':
 							if ($object['edit'] && MANAGED_OBJECT_RIGHTS_EDIT) {
-								$this->setRights($this->getRights() | ALBUM_RIGHTS);
+								$new_rights = $new_rights | ALBUM_RIGHTS;
 							}
 							break;
 						case 'pages':
-							$this->setRights($this->getRights() | ZENPAGE_PAGES_RIGHTS);
+							$new_rights = $new_rights | ZENPAGE_PAGES_RIGHTS;
 							break;
 						case 'news':
-							$this->setRights($this->getRights() | ZENPAGE_NEWS_RIGHTS);
+							$new_rights = $new_rights | ZENPAGE_NEWS_RIGHTS;
 							break;
 					}
 				}
 			}
+			if($this->getGroup()) {
+				$this->preservePrimeAlbum();
+			}
+			if ($new_rights) {
+				$this->setRights($rights | $new_rights);
+			}
 		}
 	}
 
-		/**
+	/**
 	 * Returns the unformatted date
 	 *
 	 * @return date
@@ -1339,12 +1401,14 @@ class Zenphoto_Administrator extends PersistentObject {
 	 * @param $pwd
 	 */
 	function setPass($pwd) {
-		$pwd = Zenphoto_Authority::passwordHash($this->getUser(),$pwd);
+		$hash_type = getOption('strong_hash');
+		$pwd = Zenphoto_Authority::passwordHash($this->getUser(), $pwd, $hash_type);
 		$this->set('pass', $pwd);
 		$this->set('passupdate', date('Y-m-d H:i:s'));
-		$this->set('passhash', $this->passhash);
+		$this->set('passhash', $hash_type);
 		return $this->get('pass');
 	}
+
 	/**
 	 * Returns stored password hash
 	 */
@@ -1358,6 +1422,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setName($admin_n) {
 		$this->set('name', $admin_n);
 	}
+
 	/**
 	 * Returns the user name
 	 */
@@ -1371,6 +1436,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setEmail($admin_e) {
 		$this->set('email', $admin_e);
 	}
+
 	/**
 	 * Returns the user email
 	 */
@@ -1384,6 +1450,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setRights($rights) {
 		$this->set('rights', $rights);
 	}
+
 	/**
 	 * Returns user rights
 	 */
@@ -1397,17 +1464,18 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setObjects($objects) {
 		$this->objects = $objects;
 	}
+
 	/**
 	 * Saves local copy of managed objects.
 	 * NOTE: The database is NOT updated by this, the user object MUST be saved to
 	 * cause an update
 	 */
-	function getObjects($what=NULL) {
+	function getObjects($what = NULL) {
 		if (is_null($this->objects)) {
 			if ($this->transient) {
 				$this->objects = array();
 			} else {
-				$this->objects = populateManagedObjectsList(NULL,$this->getID());
+				$this->objects = populateManagedObjectsList(NULL, $this->getID());
 			}
 		}
 		if (empty($what)) {
@@ -1416,8 +1484,7 @@ class Zenphoto_Administrator extends PersistentObject {
 		$result = array();
 		foreach ($this->objects as $object) {
 			if ($object['type'] == $what) {
-				$result[$object['name']] = $object['data'];
-				break;
+				$result[get_language_string($object['name'])] = $object['data'];
 			}
 		}
 		return $result;
@@ -1429,6 +1496,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setCustomData($custom_data) {
 		$this->set('custom_data', $custom_data);
 	}
+
 	/**
 	 * Returns custom data
 	 */
@@ -1442,6 +1510,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setValid($valid) {
 		$this->set('valid', $valid);
 	}
+
 	/**
 	 * Returns the valid flag
 	 */
@@ -1456,6 +1525,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setGroup($group) {
 		$this->set('group', $group);
 	}
+
 	/**
 	 * Returns user's group
 	 */
@@ -1469,6 +1539,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function setUser($user) {
 		$this->set('user', $user);
 	}
+
 	/**
 	 * Returns user's user id
 	 */
@@ -1480,8 +1551,9 @@ class Zenphoto_Administrator extends PersistentObject {
 	 * Sets the users quota
 	 */
 	function setQuota($v) {
-		$this->set('quota',$v);
+		$this->set('quota', $v);
 	}
+
 	/**
 	 * Returns the users quota
 	 */
@@ -1495,11 +1567,12 @@ class Zenphoto_Administrator extends PersistentObject {
 	function getLanguage() {
 		return $this->get('language');
 	}
+
 	/**
 	 * Sets the user's preferec language
 	 */
-		function setLanguage($locale) {
-		$this->set('language',$locale);
+	function setLanguage($locale) {
+		$this->set('language', $locale);
 	}
 
 	/**
@@ -1507,18 +1580,20 @@ class Zenphoto_Administrator extends PersistentObject {
 	 */
 	function save() {
 		global $_zp_gallery;
-		if (DEBUG_LOGIN) { debugLogVar("Zenphoto_Administrator->save()", $this); }
+		if (DEBUG_LOGIN) {
+			debugLogVar("Zenphoto_Administrator->save()", $this);
+		}
 		$objects = $this->getObjects();
 		if (is_null($this->get('date'))) {
-			$this->set('date',date('Y-m-d H:i:s'));
+			$this->set('date', date('Y-m-d H:i:s'));
 		}
 		parent::save();
 		$id = $this->getID();
 		if (is_array($objects)) {
-			$sql = "DELETE FROM ".prefix('admin_to_object').' WHERE `adminid`='.$id;
-			$result = query($sql,false);
+			$sql = "DELETE FROM " . prefix('admin_to_object') . ' WHERE `adminid`=' . $id;
+			$result = query($sql, false);
 			foreach ($objects as $object) {
-				if (array_key_exists('edit',$object)) {
+				if (array_key_exists('edit', $object)) {
 					$edit = $object['edit'] | 32767 & ~(MANAGED_OBJECT_RIGHTS_EDIT | MANAGED_OBJECT_RIGHTS_UPLOAD | MANAGED_OBJECT_RIGHTS_VIEW);
 				} else {
 					$edit = 32767;
@@ -1527,24 +1602,24 @@ class Zenphoto_Administrator extends PersistentObject {
 					case 'album':
 						$album = newAlbum($object['data']);
 						$albumid = $album->getID();
-						$sql = "INSERT INTO ".prefix('admin_to_object')." (adminid, objectid, type, edit) VALUES ($id, $albumid, 'albums', $edit)";
+						$sql = "INSERT INTO " . prefix('admin_to_object') . " (adminid, objectid, type, edit) VALUES ($id, $albumid, 'albums', $edit)";
 						$result = query($sql);
 						break;
 					case 'pages':
-						$sql = 'SELECT * FROM '.prefix('pages').' WHERE `titlelink`='.db_quote($object['data']);
+						$sql = 'SELECT * FROM ' . prefix('pages') . ' WHERE `titlelink`=' . db_quote($object['data']);
 						$result = query_single_row($sql);
 						if (is_array($result)) {
 							$objectid = $result['id'];
-							$sql = "INSERT INTO ".prefix('admin_to_object')." (adminid, objectid, type, edit) VALUES ($id, $objectid, 'pages', $edit)";
+							$sql = "INSERT INTO " . prefix('admin_to_object') . " (adminid, objectid, type, edit) VALUES ($id, $objectid, 'pages', $edit)";
 							$result = query($sql);
 						}
 						break;
 					case 'news':
-						$sql = 'SELECT * FROM '.prefix('news_categories').' WHERE `titlelink`='.db_quote($object['data']);
+						$sql = 'SELECT * FROM ' . prefix('news_categories') . ' WHERE `titlelink`=' . db_quote($object['data']);
 						$result = query_single_row($sql);
 						if (is_array($result)) {
 							$objectid = $result['id'];
-							$sql = "INSERT INTO ".prefix('admin_to_object')." (adminid, objectid, type, edit) VALUES ($id, $objectid, 'news', $edit)";
+							$sql = "INSERT INTO " . prefix('admin_to_object') . " (adminid, objectid, type, edit) VALUES ($id, $objectid, 'news', $edit)";
 							$result = query($sql);
 						}
 						break;
@@ -1561,10 +1636,10 @@ class Zenphoto_Administrator extends PersistentObject {
 		$album = $this->getAlbum();
 		$id = $this->getID();
 		if (parent::remove()) {
-			if (!empty($album)) {	//	Remove users album as well
+			if (!empty($album)) { //	Remove users album as well
 				$album->remove();
 			}
-			$sql = "DELETE FROM ".prefix('admin_to_object')." WHERE `adminid`=$id";
+			$sql = "DELETE FROM " . prefix('admin_to_object') . " WHERE `adminid`=$id";
 			$result = query($sql);
 		} else {
 			return false;
@@ -1578,7 +1653,7 @@ class Zenphoto_Administrator extends PersistentObject {
 	function getAlbum() {
 		$id = $this->get('prime_album');
 		if (!empty($id)) {
-			$sql = 'SELECT `folder` FROM '.prefix('albums').' WHERE `id`='.$id;
+			$sql = 'SELECT `folder` FROM ' . prefix('albums') . ' WHERE `id`=' . $id;
 			$result = query_single_row($sql);
 			if ($result) {
 				$album = newAlbum($result['folder']);
@@ -1604,36 +1679,32 @@ class Zenphoto_Administrator extends PersistentObject {
 	 * Data to support other credential systems integration
 	 */
 	function getCredentials() {
-		$cred = $this->get('other_credentials');
-		if ($cred) {
-			return unserialize($cred);
-		} else {
-			return array();
-		}
+		return getSerializedArray($this->get('other_credentials'));
 	}
+
 	function setCredentials($cred) {
-		$this->set('other_credentials',serialize($cred));
+		$this->set('other_credentials', serialize($cred));
 	}
 
 	/**
 	 * Creates a "prime" album for the user. Album name is based on the userid
 	 */
-	function createPrimealbum($new=true, $name=NULL) {
+	function createPrimealbum($new = true, $name = NULL) {
 		//	create his album
 		$t = 0;
 		$ext = '';
 		if (is_null($name)) {
-			$filename = internalToFilesystem(str_replace(array('<', '>', ':', '"'. '/'. '\\', '|', '?', '*'), '_', seoFriendly($this->getUser())));
+			$filename = internalToFilesystem(str_replace(array('<', '>', ':', '"' . '/' . '\\', '|', '?', '*'), '_', seoFriendly($this->getUser())));
 		} else {
-			$filename = internalToFilesystem(str_replace(array('<', '>', ':', '"'. '/'. '\\', '|', '?', '*'), '_', $name));
+			$filename = internalToFilesystem(str_replace(array('<', '>', ':', '"' . '/' . '\\', '|', '?', '*'), '_', $name));
 		}
-		while ($new && file_exists(ALBUM_FOLDER_SERVERPATH.$filename.$ext)) {
+		while ($new && file_exists(ALBUM_FOLDER_SERVERPATH . $filename . $ext)) {
 			$t++;
-			$ext = '-'.$t;
+			$ext = '-' . $t;
 		}
-		$path = ALBUM_FOLDER_SERVERPATH.$filename.$ext;
-		$albumname = filesystemToInternal($filename.$ext);
-		if (@mkdir_recursive($path,FOLDER_MOD)) {
+		$path = ALBUM_FOLDER_SERVERPATH . $filename . $ext;
+		$albumname = filesystemToInternal($filename . $ext);
+		if (@mkdir_recursive($path, FOLDER_MOD)) {
 			$album = newAlbum($albumname);
 			if ($title = $this->getName()) {
 				$album->setTitle($title);
@@ -1650,7 +1721,7 @@ class Zenphoto_Administrator extends PersistentObject {
 				$subrights = $subrights | MANAGED_OBJECT_RIGHTS_UPLOAD;
 			}
 			$objects = $this->getObjects();
-			$objects[] = array('data'=>$albumname, 'name'=>$albumname, 'type'=>'album', 'edit'=>$subrights);
+			$objects[] = array('data' => $albumname, 'name' => $albumname, 'type' => 'album', 'edit' => $subrights);
 			$this->setObjects($objects);
 		}
 	}
@@ -1658,14 +1729,14 @@ class Zenphoto_Administrator extends PersistentObject {
 	function getChallengePhraseInfo() {
 		$info = $this->get('challenge_phrase');
 		if ($info) {
-			return unserialize($info);
+			return getSerializedArray($info);
 		} else {
-			return array('challenge'=>'', 'response'=>'');
+			return array('challenge' => '', 'response' => '');
 		}
 	}
 
 	function setChallengePhraseInfo($challenge, $response) {
-		$this->set('challenge_phrase', serialize(array('challenge'=>$challenge,'response'=>$response)));
+		$this->set('challenge_phrase', serialize(array('challenge' => $challenge, 'response' => $response)));
 	}
 
 	/**
@@ -1674,6 +1745,33 @@ class Zenphoto_Administrator extends PersistentObject {
 	 */
 	function getLastLogon() {
 		return $this->get('lastloggedin');
+	}
+	
+	/**
+	 * Preserves the user's prime album as managed album even if he is in a group the album is actually set as managed
+	 */
+	function preservePrimeAlbum() {
+		$primeAlbum = $this->getAlbum();
+		if (is_object($primeAlbum)) {
+			$primealbum_name = $primeAlbum->name;
+			$objects = $this->getObjects();
+			$primealbum_managed = false;
+			foreach ($objects as $key => $val) {
+				if ($val['type'] == 'album' && $val['name'] == $primealbum_name) {
+					$primealbum_managed = true;
+					break;
+				}
+			}
+			if (!$primealbum_managed) {
+				$objects[] = array(
+						'data' => $primealbum_name,
+						'name' => $primealbum_name,
+						'type' => 'album',
+						'edit' => 32765
+				);
+			}
+			$this->setObjects($objects);
+		}
 	}
 
 }

--- a/ldapLogon.php
+++ b/ldapLogon.php
@@ -21,7 +21,6 @@ class ldapLogon {
 		setOptionDefault('ldapServer', '192.168.1.14');
 		setOptionDefault('ldapServerPort','389');
 		setOptionDefault('ldapSearchBase','cn=users,cn=accounts,dc=example,dc=com');
-		setOptionDefault('ldapSearchBaseGroup','cn=groups,cn=accounts,dc=example,dc=com');
 		setOptionDefault('ldapLoginAttribute','cn');
 		setOptionDefault('ldapAuthAttribute','cn');
 		setOptionDefault('ldapUserFilter','');
@@ -32,7 +31,7 @@ class ldapLogon {
 	}
 	function getOptionsSupported(){
 		$options = 	array(
-			gettext('Enable LDAP Logon') => array('key' => 'ldapEnabled', 
+			gettext('Enable LDAP Logon') => array('key' => 'ldapEnabled',
 								'type' => OPTION_TYPE_CHECKBOX,
 								'order' => 0,
 								'desc' => gettext("Set the checkbox to enable the LDAP logon functionality")
@@ -52,46 +51,42 @@ class ldapLogon {
 								'order' => 3,
 								'desc' => gettext("Set the LDAP search base for users"),
 							),
-			gettext('LDAP Search Base for Groups') => array('key' => 'ldapSearchBaseGroup',
-								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 4,
-								'desc' => gettext("Set the LDAP search base for groups"),
-							),
 			gettext('LDAP Login Attribute') => array('key' => 'ldapLoginAttribute',
 								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 5,
+								'order' => 4,
 								'desc' => gettext("Set the LDAP attribute the users must enter on ZenPhoto to login (e.g. mail to login with mailaddress, uid to login with username, etc.)"),
 							),
 			gettext('LDAP Auth Attribute') => array('key' => 'ldapAuthAttribute',
 								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 6,
+								'order' => 5,
 								'desc' => gettext("Set the LDAP attribute used to authenticate against LDAP (e.g. the first part of a fully distinguished name)"),
 							),
 			gettext('LDAP User Filter') => array('key' => 'ldapUserFilter',
 								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 7,
+								'order' => 6,
 								'desc' => gettext("Set an additional filter for users (e.g.: (memberOf=cn=zenphoto-user,cn=groups,cn=accounts,dc=example,dc=com) to only allow users that are members of the zenphoto-user LDAP group to log in)"),
 							),
 			gettext('LDAP Reader DN') => array('key' => 'ldapReaderDn',
 								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 8,
+								'order' => 7,
 								'desc' => gettext("Set the DN of an LDAP-user with read permissions for the user and group objects"),
 							),
 			gettext('LDAP Reader Password') => array('key' => 'ldapReaderPass',
 								'type' => OPTION_TYPE_PASSWORD,
-								'order' => 9,
+								'order' => 8,
 								'desc' => gettext("Password of the LDAP-User with read permissions for the user and group objects"),
 							),
 			gettext('Default template') => array('key' => 'ldapZenDefaultTemplate',
 								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 10,
+								'order' => 9,
 								'desc' => gettext("Template that should be used when no ldap zen-group is available")
 							)
 		);
 		return $options;
 	}
+
 	function handleOption($option, $currentValue) {
-  	}
+	}
 
 	/*
 	 * returns a LDAP connection
@@ -111,29 +106,16 @@ class ldapLogon {
 		}
 	}
 
-	/*
-	 * Returns the array uids of a cn
-	 *
-	 * @param ldapServer
-	 * @param ldapServerPort
-	 * @param ldapDc in format 'dc=domain' or 'dc=domain,dc=tld'
-	 * @param ldapCn in format 'cn=user'
-	 */
-	static function getLdapUidsOfCn($ldapServer,$ldapServerPort,$ldapDc,$ldapCn) {
-		if($ldapServer == NULL || $ldapServerPort == NULL || $ldapDc == NULL || $ldapCn == NULL) {
-			debugLog('LDAP: function getLdapUidsOfCn() called with at least one invalid argument!');
-			return false;
-		}
-		if($ldapC = self::getLdapConnection($ldapServer,$ldapServerPort)) {
-			if(@ldap_bind($ldapC, getOption('ldapRdrDn'), getOption('ldapRdrPass'))) {
-				$res = ldap_search($ldapC,$ldapDc, $ldapCn);
-				$user = ldap_get_entries($ldapC,$res);
-				unset($user[0]['uid']['count']);
+	static function getLdapObjects($ldapServer, $ldapServerPort, $ldapSearchBase, $filter){
+		if ($ldapC = self::getLdapConnection($ldapServer,$ldapServerPort)){
+			if(@ldap_bind($ldapC, getOption('ldapReaderDn'), getOption('ldapReaderPass'))){
+				$res = ldap_search($ldapC, $ldapSearchBase, $filter);
+				$objects = ldap_get_entries($ldapC, $res);
 				ldap_close($ldapC);
-				return $user[0]['uid'];
+				return $objects;
 			} else {
 				debugLog("Cannot bind to LDAP-server:".ldap_error($ldapC));
-                                ldap_close($ldapC);
+				ldap_close($ldapC);
 				return false;
 			}
 		} else {
@@ -141,119 +123,40 @@ class ldapLogon {
 			return false;
 		}
 	}
-	
-	/*
-	 * Returns an array of CNs of a given uid
-	 *
-	 * @param ldapServer
-	 * @param ldapServerPort
-	 * @param ldapDc in format 'dc=domain' or 'dc=domain,dc=tld'
-	 * @param ldapUid in format 'memberUid=user'
-	 * @param ldapAttr
-	 */
-	static function getLdapGroupCnsOfUid($ldapServer,$ldapServerPort,$ldapDc,$ldapUid , $ldapAttr = "") {
-		if($ldapServer == NULL || $ldapServerPort == NULL || $ldapDc == NULL || $ldapUid == NULL || $ldapAttr == NULL) {
-			debugLog('LDAP: function getLdapZenUsers() called with at least one invalid argument!');
-			return false;
-		}
-		if($ldapC = self::getLdapConnection($ldapServer,$ldapServerPort)) {
-			if(@ldap_bind($ldapC, getOption('ldapRdrDn'), getOption('ldapRdrPass'))) {
-				$groups = array();
-				$res = ldap_search($ldapC,$ldapDc, $ldapUid, $ldapAttr);
-				$user = ldap_get_entries($ldapC,$res);
-				for($i=0;$i < count($user); $i++) {
-						if(!empty($user[$i]['cn']['0'])) {
-								$groups[$i] = $user[$i]['cn']['0'];
-						}
-				}
-				ldap_close($ldapC);
-				return $groups;
-			} else {
-				debugLog("Cannot bind to LDAP-server:".ldap_error($ldapC));
-                                ldap_close($ldapC);
-				return false;
-			}
-		} else {
-			debugLog("Cannot connect to LDAP-server:".ldap_error($ldapC));
-			return false;
-		}
-	}	
 
-	/*
-         * Return an Array with the group of a given user
-         * @param ldapServer
-         * @param ldapServerPort
-         * @param ldapDc in format 'dc=domain' or 'dc=domain,dc=tld'
-         * @param ldapCn in format 'cn=user'
-         * @param ldapFilter is the ldap-filter attribute, typically "memberof"
-         */
-	static function getAdUserGroups($ldapServer, $ldapServerPort, $ldapDc, $ldapCn,$ldapFilter = array('memberof')) {
-                if($ldapC = self::getLdapConnection($ldapServer,$ldapServerPort)) {
-                        if(@ldap_bind($ldapC, getOption('ldapRdrDn'), getOption('ldapRdrPass'))) {
-	                        $res = ldap_search($ldapC,$ldapDc, $ldapCn,$ldapFilter) or die(ldap_error($ldapC));
-	                        $groups = ldap_get_entries($ldapC,$res);
-	                        ldap_close($ldapC);
-				if(array_key_exists('memberof',$groups[0]) ){
-		                        $tmp=$groups[0]['memberof'];
-		                        $groups=array();
-	        	                unset($tmp['count']);
-	                	        foreach($tmp as $member) {
-	                        	        $t=explode(",",$member);
-	                                	$t=explode("=",$t[0]);
-		                                array_push($groups,$t[1]);
-		                        }
-	        	                return $groups;
-				} else {
-					debugLog("Groups cannot be retrieved, check your LDAP-Settings, especially the DC, Reader, Readerpassword; Search called with: ldap_search($ldapC,$ldapDc, $ldapCn,$ldapFilter)");
-					
-					return array();
-				}
-			} else { 
-				debugLog("Cannot bind to LDAP-server:".ldap_error($ldapC));
-				ldap_close($ldapC);
-				return false;
-			}
-                } else {
-			debugLog("Cannot connect to LDAP-server:".ldap_error($ldapC));
-                        return false;
-                }
-        }
-	
 	/*
 	 * Return an Array that is used by the external_auth.php script
 	 * @param ldapServer
 	 * @param ldapServerPort
-	 * @param ldapDc in format 'dc=domain' or 'dc=domain,dc=tld'
+	 * @param ldapSearchBase in DN format
 	 * @param user is the string from the login-textbox
 	 * @param defaultZenGroup is the default template that should be used when no group matches
 	 */
-	static function getExternalAuthArray($ldapServer,$ldapServerPort,$ldapDc, $user, $defaultZenGroup) {
-		if($ldapServer == NULL || $ldapServerPort == NULL || $ldapDc == NULL || $user == NULL) {
+	static function getExternalAuthArray($ldapServer, $ldapServerPort, $ldapSearchBase, $user, $defaultZenGroup) {
+		if($ldapServer == NULL || $ldapServerPort == NULL || $ldapSearchBase == NULL || $user == NULL) {
 			debugLog('LDAP: function getExternalAuthArray() called with at least one invalid argument!');
 			return false;
 		}
 		$result=array();
 		$i=0;
 		$result['groups']=array();
-		if(getOption('ldapType') == 'ldapTypeOL' && $ldapUids = self::getLdapUidsOfCn($ldapServer,$ldapServerPort,$ldapDc,'cn='.$user)) { // OpenLDAP is used
-			foreach($ldapUids as $uid) {
-				if(count(self::getLdapGroupCnsOfUid($ldapServer,$ldapServerPort,$ldapDc,'memberUid='.$uid, array('cn')))) {
-					$result['groups'] = array_merge($result['groups'],self::getLdapGroupCnsOfUid($ldapServer,$ldapServerPort,$ldapDc,'memberUid='.$uid, array('cn')));
-				}
+
+		$ldapObject = self::getLdapObjects($ldapServer, $ldapServerPort, $ldapSearchBase,
+			"(&".getOption('ldapUserFilter')."(".getOption('ldapLoginAttribute')."=$user))");
+		if ($ldapObject != false){
+			foreach ($ldapObject[0]['memberof'] as $group){
+				$group = preg_replace("/,.*$/", "", $group);
+				$group = preg_replace("/^.*=/", "", $group);
+				$result['groups'] = array_merge($result['groups'], array("$group"));
 			}
-		} else if (($groups = self::getAdUserGroups($ldapServer,$ldapServerPort,$ldapDc,'cn='.$user)) && getOption('ldapType') == 'ldapTypeAD') {  //MS AD is used
-			$result['groups'] = array_merge($result['groups'],$groups);
 		}
-		if(getOption('ldapType')){ 
-			$result['user'] = $user;
-        	        $result['id'] = '';
-                	$result['defaultgroup'] = $defaultZenGroup;
-			return $result;
-		} else {
-			return NULL;
-		}
+		$result['user'] = $user;
+		$result['id'] = $ldapObject[0][getOption('ldapAuthAttribute')][0];
+		$result['defaultgroup'] = $defaultZenGroup;
+		debugLog("LDAP: \$result: ".var_export($result, true));
+		return $result;
 	}
-	
+
 	/*
 	 * Make an LDAP-bind to authenticate
 	 * @param ldapServer
@@ -285,22 +188,22 @@ class ldapLogon {
 
 	/**
 	 * getLogon is used to return the userobj without authentication, used for cookie-stuf
-	 * 
+	 *
 	 * @param id of the user, should be -1 if using ldap-logon
 	 */
 	static function getLogon($id) {
 		global $_zp_current_admin_obj;
 		if ($id == -1 ){
-                        if (DEBUG_LOGIN) { debugLog("Using LDAP Authorization, getting LDAP-Cookie: User=".zp_getCookie('zp_user_auth_ldap')); }
-                        if($_zp_current_admin_obj = self::checkLogon(zp_getCookie('zp_user_auth_ldap'))) {
-                                return $_zp_current_admin_obj->getRights();
-                        }
-                }
+			if (DEBUG_LOGIN) { debugLog("Using LDAP Authorization, getting LDAP-Cookie: User=".zp_getCookie('zp_user_auth_ldap')); }
+			if($_zp_current_admin_obj = self::checkLogon(zp_getCookie('zp_user_auth_ldap'))) {
+				return $_zp_current_admin_obj->getRights();
+			}
+		}
 	}
-	
+
 	/**
 	 * checkLogon for LDAP
-	 * 
+	 *
 	 * @param user is the username
 	 * @param pass can be null if no authentication should be done
 	 */
@@ -308,74 +211,77 @@ class ldapLogon {
 		$auth = 'external';
 		$searchfor = array('`user`=' => $user,  '`valid`=' => 1);
 		$userobj = Zenphoto_Authority::getAnAdmin($searchfor);
-		if (!$userobj ) {
-			$result = ldapLogon::getExternalAuthArray(getOption('ldapServer'),getOption('ldapServerPort'),getOption('ldapDc'),$user,getOption('ldapZenDefaultTemplate'));
+		if (!$userobj) {
+			$result = ldapLogon::getExternalAuthArray(getOption('ldapServer'),getOption('ldapServerPort'),getOption('ldapSearchBase'),$user,getOption('ldapZenDefaultTemplate'));
 			if($result){
+				$user = $result['id'];
 				unset($result['id']);
 				unset($result['user']);
 				$authority = '';
+				//	create a transient user
 				$userobj = new Zenphoto_Administrator('', 1);
 				$userobj->setUser($user);
 				$userobj->setRights(NO_RIGHTS);
+					//	Flag as external credentials for completeness
 				$properties = array_keys($result);
 				array_unshift($properties, $auth);
 				$userobj->setCredentials($properties);
-				$member = false; 
+				$member = false;
 				foreach ($result as $key=>$value) {
 					switch ($key) {
-						case 'authority':
-							$authority = '::'.$value;
-							unset($result['authority']);
-							break;
-						case 'groups':
-							$rights = NO_RIGHTS;
-							$objects = array();
-							$groups = $value;
-							foreach ($groups as $key=>$group) {
-								if (DEBUG_LOGIN){ debugLog("LDAP: Adding Group: $group"); }
-								$groupobj = Zenphoto_Authority::getAnAdmin(array('`user`=' => $group,'`valid`=' => 0));
-								if ($groupobj) {
-									$member = true;
-									$rights = $groupobj->getRights() | $rights;
-									$objects = array_merge($groupobj->getObjects(), $objects);
-									if ($groupobj->getName() == 'template') {
-										unset($groups[$key]);
-									}
-								} else {
+					case 'authority':
+						$authority = '::'.$value;
+						unset($result['authority']);
+						break;
+					case 'groups':
+						$rights = NO_RIGHTS;
+						$objects = array();
+						$groups = $value;
+						foreach ($groups as $key=>$group) {
+							if (DEBUG_LOGIN){ debugLog("LDAP: Adding Group: $group"); }
+							$groupobj = Zenphoto_Authority::getAnAdmin(array('`user`=' => $group,'`valid`=' => 0));
+							if ($groupobj) {
+								$member = true;
+								$rights = $groupobj->getRights() | $rights;
+								$objects = array_merge($groupobj->getObjects(), $objects);
+								if ($groupobj->getName() == 'template') {
 									unset($groups[$key]);
 								}
+							} else {
+								unset($groups[$key]);
 							}
-							if ($member) {
-								$userobj->setGroup(implode(',',$groups));
+						}
+						if ($member) {
+							$userobj->setGroup(implode(',',$groups));
+							$userobj->setRights($rights);
+							$userobj->setObjects($objects);
+						}
+						break;
+					case 'defaultgroup':
+						if (!$member && isset($result['defaultgroup'])) {
+							$group = $result['defaultgroup'];
+							$groupobj = Zenphoto_Authority::getAnAdmin(array('`user`=' => $group,'`valid`=' => 0));
+							if ($groupobj) {
+								$rights = $groupobj->getRights();
+								$objects = $groupobj->getObjects();
+								if ($groupobj->getName() != 'template') {
+									$group = NULL;
+								}
+								$userobj->setGroup($group);
 								$userobj->setRights($rights);
 								$userobj->setObjects($objects);
 							}
-							break;
-						case 'defaultgroup':
-							if (!$member && isset($result['defaultgroup'])) {
-								$group = $result['defaultgroup'];
-								$groupobj = Zenphoto_Authority::getAnAdmin(array('`user`=' => $group,'`valid`=' => 0));
-								if ($groupobj) {
-									$rights = $groupobj->getRights();
-									$objects = $groupobj->getObjects();
-									if ($groupobj->getName() != 'template') {
-										$group = NULL;
-									}
-									$userobj->setGroup($group);
-									$userobj->setRights($rights);
-									$userobj->setObjects($objects);
-								}
-							}
-							break;
-						case 'objects':
-							$userobj->setObjects($objects);
-							break;
-						case 'album':
-							$userobj->createPrimealbum(false, $value);
-							break;
-						default:
-							$userobj->set($key,$value);
-							break;
+						}
+						break;
+					case 'objects':
+						$userobj->setObjects($objects);
+						break;
+					case 'album':
+						$userobj->createPrimealbum(false, $value);
+						break;
+					default:
+						$userobj->set($key,$value);
+						break;
 					}
 				}
 				$properties = array_keys($result);
@@ -386,17 +292,18 @@ class ldapLogon {
 			}
 		} else {
 			$userobj = NULL;	// User exists in local DB, it should be authenticated before, some error?
-		}	
+		}
 		if (isset($result['logout_link'])) {
 			$userobj->logout_link = $result['logout_link'];
 		}
 		if ($pass != NULL && $userobj) {
-			$ldapRdn = 'cn='.$userobj->get('user').','.getOption('ldapOu').','.getOption('ldapDc');
+			$ldapRdn = getOption("ldapAuthAttribute").'='.$user.','.getOption('ldapSearchBase');
 			if(!ldapLogon::authenticateLdapUser(getOption('ldapServer'), getOption('ldapServerPort'), $ldapRdn, $pass)) {
 				$userobj = NULL;
 			}
 		}
+		debugLog("LDAP: \$userobj: ".var_export($userobj, true));
 		return $userobj;
-	}	
+	}
 }
 ?>

--- a/ldapLogon.php
+++ b/ldapLogon.php
@@ -16,7 +16,7 @@ zp_register_filter('','ldapLogon::checkLogon');
 zp_register_filter('','ldapLogon::getLogon');
 
 class ldapLogon {
-	function ldapLogon(){
+	function __construct(){
 		setOptionDefault('ldapEnabled', 1);
 		setOptionDefault('ldapType', 0);
 		setOptionDefault('ldapServer', '192.168.1.14');

--- a/ldapLogon.php
+++ b/ldapLogon.php
@@ -18,13 +18,15 @@ zp_register_filter('','ldapLogon::getLogon');
 class ldapLogon {
 	function __construct(){
 		setOptionDefault('ldapEnabled', 1);
-		setOptionDefault('ldapType', 0);
 		setOptionDefault('ldapServer', '192.168.1.14');
 		setOptionDefault('ldapServerPort','389');
-		setOptionDefault('ldapDc','dc=DOMAIN');
-		setOptionDefault('ldapOu','ou=Users');
-		setOptionDefault('ldapRdrDn','cn=reader,dc=DOMAIN');
-		setOptionDefault('ldapRdrPass','test');
+		setOptionDefault('ldapSearchBase','cn=users,cn=accounts,dc=example,dc=com');
+		setOptionDefault('ldapSearchBaseGroup','cn=groups,cn=accounts,dc=example,dc=com');
+		setOptionDefault('ldapLoginAttribute','cn');
+		setOptionDefault('ldapAuthAttribute','cn');
+		setOptionDefault('ldapUserFilter','');
+		setOptionDefault('ldapReaderDn','cn=reader,dc=example,dc=com');
+		setOptionDefault('ldapReaderPass','test');
 		setOptionDefault('ldapZenDefaultTemplate','extern');
 		setOption('zp_plugin_ldapLogon','4096');
 	}
@@ -35,49 +37,56 @@ class ldapLogon {
 								'order' => 0,
 								'desc' => gettext("Set the checkbox to enable the LDAP logon functionality")
 							),
-			gettext('Type of directory') => array('key' => 'ldapType',
-                                                                'type' => OPTION_TYPE_RADIO,
-								'buttons' => array(getText('Microsoft Active Directory') => "ldapTypeAD",getText("OpenLDAP") => "ldapTypeOL"),
-                                                                'order' => 1,
-                                                                'desc' => gettext("Set LDAP type: Microsoft AD or OpenLDAP")
-                                                        ),
 			gettext('LDAP Server IP/Hostname') => array('key' => 'ldapServer',
 								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 2,
+								'order' => 1,
 								'desc' => gettext("Set the LDAP server IP")
 							),
 			gettext('LDAP Server Port') => array('key' => 'ldapServerPort',
 								'type' => OPTION_TYPE_TEXTBOX,
-								'order' => 3,
+								'order' => 2,
 								'desc' => gettext("Set the LDAP server port")
 							),
-			gettext('LDAP DC') => array('key' => 'ldapDc',
+			gettext('LDAP Search Base') => array('key' => 'ldapSearchBase',
+								'type' => OPTION_TYPE_TEXTBOX,
+								'order' => 3,
+								'desc' => gettext("Set the LDAP search base for users"),
+							),
+			gettext('LDAP Search Base for Groups') => array('key' => 'ldapSearchBaseGroup',
 								'type' => OPTION_TYPE_TEXTBOX,
 								'order' => 4,
-								'desc' => gettext("Set the LDAP DC e.g. dc=domain (--> the complete User-DN is dc=Test,ou=Users,dc=domain)")
+								'desc' => gettext("Set the LDAP search base for groups"),
 							),
-			gettext('LDAP OU') => array('key' => 'ldapOu',
+			gettext('LDAP Login Attribute') => array('key' => 'ldapLoginAttribute',
 								'type' => OPTION_TYPE_TEXTBOX,
 								'order' => 5,
-								'desc' => gettext("Set the LDAP OU e.g. ou=Users (--> the complete User-DN is dc=Test,ou=Users,dc=domain), for MS AD you have to use cn=Users!")
+								'desc' => gettext("Set the LDAP attribute the users must enter on ZenPhoto to login (e.g. mail to login with mailaddress, uid to login with username, etc.)"),
 							),
-			gettext('LDAP Reader DN') => array('key' => 'ldapRdrDn',
-                                                                'type' => OPTION_TYPE_TEXTBOX,
-                                                                'order' => 6,
-                                                                'desc' => gettext("Set the DN of an LDAP-user with read permissions for the memberOf group-attributes, e.g.: cn=reader,dc=loww, for MS AD the regular login can be used e.g. user@domain.tld")
-                                                        ),
-			gettext('LDAP Reader Password') => array('key' => 'ldapRdrPass',
-                                                                'type' => OPTION_TYPE_PASSWORD,
-                                                                'order' => 7,
-                                                                'desc' => gettext("Password of the LDAP-User with read permissions to acces the memberOf group-attribute")
-                                                        ),
-			gettext('Default template') => array('key' => 'ldapZenDefaultTemplate',
+			gettext('LDAP Auth Attribute') => array('key' => 'ldapAuthAttribute',
+								'type' => OPTION_TYPE_TEXTBOX,
+								'order' => 6,
+								'desc' => gettext("Set the LDAP attribute used to authenticate against LDAP (e.g. the first part of a fully distinguished name)"),
+							),
+			gettext('LDAP User Filter') => array('key' => 'ldapUserFilter',
+								'type' => OPTION_TYPE_TEXTBOX,
+								'order' => 7,
+								'desc' => gettext("Set an additional filter for users (e.g.: (memberOf=cn=zenphoto-user,cn=groups,cn=accounts,dc=example,dc=com) to only allow users that are members of the zenphoto-user LDAP group to log in)"),
+							),
+			gettext('LDAP Reader DN') => array('key' => 'ldapReaderDn',
 								'type' => OPTION_TYPE_TEXTBOX,
 								'order' => 8,
+								'desc' => gettext("Set the DN of an LDAP-user with read permissions for the user and group objects"),
+							),
+			gettext('LDAP Reader Password') => array('key' => 'ldapReaderPass',
+								'type' => OPTION_TYPE_PASSWORD,
+								'order' => 9,
+								'desc' => gettext("Password of the LDAP-User with read permissions for the user and group objects"),
+							),
+			gettext('Default template') => array('key' => 'ldapZenDefaultTemplate',
+								'type' => OPTION_TYPE_TEXTBOX,
+								'order' => 10,
 								'desc' => gettext("Template that should be used when no ldap zen-group is available")
 							)
-
-
 		);
 		return $options;
 	}


### PR DESCRIPTION
This makes the plugin a lot more versatile, allowing the configuration to adapt to all LDAP setups (known to me, at least).
You can configure the plugin to  use any possible LDAP attribute for login (uid, cn, mail, whatever), changes the options to only use one parameter for setting the search base, add an option for additional filters (for example to restrict to members of a specific group).

This makes it possible to authenticate against openLDAP, eDirectory, freeIPA and possibly AD, too, but I don't have one handy to test.